### PR TITLE
Issue 03: return preprocessing and sampling frequency utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Local tooling
 .codex
+.claude
 .env
 .env.*
 
@@ -43,3 +44,4 @@ Thumbs.db
 
 # Local datasets
 databento.zip
+*.pdf

--- a/src/hft_hmm/__init__.py
+++ b/src/hft_hmm/__init__.py
@@ -8,6 +8,7 @@ from hft_hmm.data import (
     load_yfinance_market_data,
     validate_market_data,
 )
+from hft_hmm.preprocessing import compute_log_returns, resample_prices, train_test_split_time
 from hft_hmm.project import PROJECT_NAME, ProjectInfo, get_project_info
 
 __all__ = [
@@ -16,8 +17,11 @@ __all__ = [
     "MarketDataSpec",
     "MarketDataValidationError",
     "__version__",
+    "compute_log_returns",
     "get_project_info",
     "load_csv_market_data",
     "load_yfinance_market_data",
+    "resample_prices",
+    "train_test_split_time",
     "validate_market_data",
 ]

--- a/src/hft_hmm/preprocessing.py
+++ b/src/hft_hmm/preprocessing.py
@@ -1,0 +1,66 @@
+"""Return preprocessing and sampling frequency utilities.
+
+Engineering utility — these functions are not paper-faithful reproductions but
+support data ingestion and feature engineering pipelines.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+
+def compute_log_returns(prices: pd.Series) -> pd.Series:
+    """Compute continuously compounded log returns: ln(p_t / p_{t-1}).
+
+    The first element is NaN because there is no preceding price. Call
+    ``.dropna()`` before passing returns to model-fitting functions.
+
+    References: Engineering utility
+    """
+    return np.log(prices / prices.shift(1))
+
+
+def resample_prices(
+    frame: pd.DataFrame,
+    freq: str,
+    *,
+    price_column: str = "price",
+    timestamp_column: str = "timestamp",
+) -> pd.DataFrame:
+    """Resample market data to ``freq``, keeping the last price in each bar.
+
+    ``freq`` follows pandas offset alias notation (e.g. ``"1D"``, ``"5min"``,
+    ``"1h"``). Bars with no observations are dropped. When a ``volume`` column
+    is present it is summed within each bar. Output is sorted by timestamp.
+
+    References: Engineering utility
+    """
+    indexed = frame.set_index(timestamp_column)
+    agg: dict[str, str] = {price_column: "last"}
+    if "volume" in indexed.columns:
+        agg["volume"] = "sum"
+    resampled = indexed[list(agg.keys())].resample(freq).agg(agg).dropna(subset=[price_column])
+    return resampled.reset_index()
+
+
+def train_test_split_time(
+    frame: pd.DataFrame,
+    test_fraction: float,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Split a time-ordered DataFrame chronologically without shuffling.
+
+    ``test_fraction`` controls the proportion of rows assigned to the test set.
+    The test set always follows the training set in time, so no future data
+    leaks into the training set.
+
+    Raises ``ValueError`` for ``test_fraction`` outside the open interval (0, 1).
+
+    References: Engineering utility
+    """
+    if not (0.0 < test_fraction < 1.0):
+        raise ValueError(f"test_fraction must be in (0, 1), got {test_fraction!r}.")
+    split = int(len(frame) * (1.0 - test_fraction))
+    train = frame.iloc[:split].reset_index(drop=True)
+    test = frame.iloc[split:].reset_index(drop=True)
+    return train, test

--- a/src/hft_hmm/preprocessing.py
+++ b/src/hft_hmm/preprocessing.py
@@ -18,6 +18,18 @@ def compute_log_returns(prices: pd.Series) -> pd.Series:
 
     References: Engineering utility
     """
+    non_positive = prices <= 0
+    if non_positive.any():
+        bad_positions = np.flatnonzero(non_positive.to_numpy())
+        if len(bad_positions) > 5:
+            shown = ", ".join(str(pos) for pos in bad_positions[:5])
+            location_hint = f"{shown}, ..."
+        else:
+            location_hint = ", ".join(str(pos) for pos in bad_positions)
+        raise ValueError(
+            "prices must be strictly positive to compute log returns; "
+            f"found {len(bad_positions)} non-positive value(s) at position(s): {location_hint}."
+        )
     return np.log(prices / prices.shift(1))
 
 
@@ -36,9 +48,9 @@ def resample_prices(
 
     References: Engineering utility
     """
-    indexed = frame.set_index(timestamp_column)
+    indexed = frame.set_index(timestamp_column).sort_index()
     agg: dict[str, str] = {price_column: "last"}
-    if "volume" in indexed.columns:
+    if "volume" in indexed.columns and price_column != "volume":
         agg["volume"] = "sum"
     resampled = indexed[list(agg.keys())].resample(freq).agg(agg).dropna(subset=[price_column])
     return resampled.reset_index()
@@ -64,7 +76,7 @@ def train_test_split_time(
     if len(frame) < 2:
         raise ValueError("frame must contain at least 2 rows for a chronological split.")
     split = int(len(frame) * (1.0 - test_fraction))
-    if split == 0 or split == len(frame):
+    if split == 0:
         raise ValueError(
             "test_fraction and frame length must yield non-empty train and test splits."
         )

--- a/src/hft_hmm/preprocessing.py
+++ b/src/hft_hmm/preprocessing.py
@@ -54,13 +54,20 @@ def train_test_split_time(
     The test set always follows the training set in time, so no future data
     leaks into the training set.
 
-    Raises ``ValueError`` for ``test_fraction`` outside the open interval (0, 1).
+    Raises ``ValueError`` for ``test_fraction`` outside the open interval (0, 1),
+    or when the input is too short to produce non-empty train and test splits.
 
     References: Engineering utility
     """
     if not (0.0 < test_fraction < 1.0):
         raise ValueError(f"test_fraction must be in (0, 1), got {test_fraction!r}.")
+    if len(frame) < 2:
+        raise ValueError("frame must contain at least 2 rows for a chronological split.")
     split = int(len(frame) * (1.0 - test_fraction))
+    if split == 0 or split == len(frame):
+        raise ValueError(
+            "test_fraction and frame length must yield non-empty train and test splits."
+        )
     train = frame.iloc[:split].reset_index(drop=True)
     test = frame.iloc[split:].reset_index(drop=True)
     return train, test

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -44,6 +44,11 @@ def test_compute_log_returns_constant_prices_give_zero() -> None:
     assert returns.dropna().tolist() == pytest.approx([0.0, 0.0])
 
 
+def test_compute_log_returns_rejects_non_positive_prices() -> None:
+    with pytest.raises(ValueError, match="strictly positive"):
+        compute_log_returns(pd.Series([100.0, 0.0, 101.0]))
+
+
 # --- resample_prices ---
 
 
@@ -79,7 +84,8 @@ def test_resample_prices_drops_empty_bars() -> None:
         ["2024-01-02 09:30:00", "2024-01-05 09:30:00"],
     )
     result = resample_prices(frame, "1D")
-    assert len(result) == 2
+    timestamps = result["timestamp"].dt.strftime("%Y-%m-%d").tolist()
+    assert timestamps == ["2024-01-02", "2024-01-05"]
 
 
 def test_resample_prices_sums_volume_within_bar() -> None:
@@ -132,13 +138,10 @@ def test_train_test_split_combined_covers_all_rows() -> None:
 
 
 def test_train_test_split_invalid_fraction_raises() -> None:
-    frame = _make_frame([100.0], ["2024-01-01 09:30:00"])
-    with pytest.raises(ValueError):
-        train_test_split_time(frame, test_fraction=0.0)
-    with pytest.raises(ValueError):
-        train_test_split_time(frame, test_fraction=1.0)
-    with pytest.raises(ValueError):
-        train_test_split_time(frame, test_fraction=1.5)
+    frame = _make_frame([100.0, 101.0], ["2024-01-01 09:30:00", "2024-01-02 09:30:00"])
+    for invalid_fraction in (0.0, 1.0, 1.5, -0.1):
+        with pytest.raises(ValueError, match="test_fraction must be in"):
+            train_test_split_time(frame, test_fraction=invalid_fraction)
 
 
 def test_train_test_split_rejects_insufficient_rows() -> None:

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -1,0 +1,141 @@
+"""Tests for return preprocessing and sampling frequency utilities."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from hft_hmm.preprocessing import compute_log_returns, resample_prices, train_test_split_time
+
+
+def _make_frame(prices: list[float], timestamps: list[str]) -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "timestamp": pd.to_datetime(timestamps, utc=True),
+            "price": prices,
+        }
+    )
+
+
+# --- compute_log_returns ---
+
+
+def test_compute_log_returns_values() -> None:
+    prices = pd.Series([100.0, 110.0, 99.0])
+    returns = compute_log_returns(prices)
+    assert np.isnan(returns.iloc[0])
+    assert returns.iloc[1] == pytest.approx(np.log(110.0 / 100.0))
+    assert returns.iloc[2] == pytest.approx(np.log(99.0 / 110.0))
+
+
+def test_compute_log_returns_preserves_length() -> None:
+    prices = pd.Series([1.0, 2.0, 4.0, 8.0])
+    assert len(compute_log_returns(prices)) == len(prices)
+
+
+def test_compute_log_returns_first_is_nan() -> None:
+    returns = compute_log_returns(pd.Series([50.0, 51.0]))
+    assert np.isnan(returns.iloc[0])
+
+
+def test_compute_log_returns_constant_prices_give_zero() -> None:
+    returns = compute_log_returns(pd.Series([100.0, 100.0, 100.0]))
+    assert returns.dropna().tolist() == pytest.approx([0.0, 0.0])
+
+
+# --- resample_prices ---
+
+
+def test_resample_prices_daily_from_intraday() -> None:
+    frame = _make_frame(
+        [100.0, 101.0, 102.0, 103.0],
+        [
+            "2024-01-02 09:30:00",
+            "2024-01-02 15:00:00",
+            "2024-01-03 09:30:00",
+            "2024-01-03 15:00:00",
+        ],
+    )
+    result = resample_prices(frame, "1D")
+    assert len(result) == 2
+    assert result["price"].tolist() == pytest.approx([101.0, 103.0])
+
+
+def test_resample_prices_preserves_ascending_order() -> None:
+    frame = _make_frame(
+        [100.0, 101.0, 102.0],
+        ["2024-01-04 09:30:00", "2024-01-02 09:30:00", "2024-01-03 09:30:00"],
+    )
+    frame = frame.sort_values("timestamp").reset_index(drop=True)
+    result = resample_prices(frame, "1D")
+    timestamps = result["timestamp"].tolist()
+    assert timestamps == sorted(timestamps)
+
+
+def test_resample_prices_drops_empty_bars() -> None:
+    frame = _make_frame(
+        [100.0, 105.0],
+        ["2024-01-02 09:30:00", "2024-01-05 09:30:00"],
+    )
+    result = resample_prices(frame, "1D")
+    assert len(result) == 2
+
+
+def test_resample_prices_sums_volume_within_bar() -> None:
+    frame = pd.DataFrame(
+        {
+            "timestamp": pd.to_datetime(["2024-01-02 09:30:00", "2024-01-02 15:00:00"], utc=True),
+            "price": [100.0, 101.0],
+            "volume": [10.0, 20.0],
+        }
+    )
+    result = resample_prices(frame, "1D")
+    assert result["volume"].iloc[0] == pytest.approx(30.0)
+
+
+def test_resample_prices_single_tick_per_bar() -> None:
+    frame = _make_frame([200.0, 210.0], ["2024-01-02 09:30:00", "2024-01-03 09:30:00"])
+    result = resample_prices(frame, "1D")
+    assert result["price"].tolist() == pytest.approx([200.0, 210.0])
+
+
+# --- train_test_split_time ---
+
+
+def test_train_test_split_no_leakage() -> None:
+    frame = _make_frame(
+        list(range(1, 11)),
+        [f"2024-01-{i:02d} 09:30:00" for i in range(1, 11)],
+    )
+    train, test = train_test_split_time(frame, test_fraction=0.3)
+    assert train["timestamp"].max() < test["timestamp"].min()
+
+
+def test_train_test_split_sizes() -> None:
+    frame = _make_frame(
+        [float(i) for i in range(10)],
+        [f"2024-01-{i + 1:02d} 09:30:00" for i in range(10)],
+    )
+    train, test = train_test_split_time(frame, test_fraction=0.2)
+    assert len(train) == 8
+    assert len(test) == 2
+
+
+def test_train_test_split_combined_covers_all_rows() -> None:
+    frame = _make_frame(
+        [float(i) for i in range(20)],
+        [f"2024-01-{i + 1:02d} 09:30:00" for i in range(20)],
+    )
+    train, test = train_test_split_time(frame, test_fraction=0.25)
+    assert len(train) + len(test) == len(frame)
+
+
+def test_train_test_split_invalid_fraction_raises() -> None:
+    frame = _make_frame([100.0], ["2024-01-01 09:30:00"])
+    with pytest.raises(ValueError):
+        train_test_split_time(frame, test_fraction=0.0)
+    with pytest.raises(ValueError):
+        train_test_split_time(frame, test_fraction=1.0)
+    with pytest.raises(ValueError):
+        train_test_split_time(frame, test_fraction=1.5)

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -139,3 +139,15 @@ def test_train_test_split_invalid_fraction_raises() -> None:
         train_test_split_time(frame, test_fraction=1.0)
     with pytest.raises(ValueError):
         train_test_split_time(frame, test_fraction=1.5)
+
+
+def test_train_test_split_rejects_insufficient_rows() -> None:
+    frame = _make_frame([100.0], ["2024-01-01 09:30:00"])
+    with pytest.raises(ValueError, match="at least 2 rows"):
+        train_test_split_time(frame, test_fraction=0.5)
+
+
+def test_train_test_split_rejects_empty_partition() -> None:
+    frame = _make_frame([100.0, 101.0], ["2024-01-01 09:30:00", "2024-01-02 09:30:00"])
+    with pytest.raises(ValueError, match="non-empty train and test splits"):
+        train_test_split_time(frame, test_fraction=0.9)


### PR DESCRIPTION
## Summary
- add preprocessing utilities for log returns, resampling, and chronological train/test splits
- expose the new helpers from the package root
- cover synthetic return, resampling, and insufficient-row edge cases with tests

## Validation
- pytest
- ruff check .
- mypy src

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three preprocessing utilities for time-series market data: log-return computation, configurable price resampling, and chronological train/test splitting—now exposed via the main package API.
* **Tests**
  * New test suite validating correctness, error handling, resampling behavior, and temporal split guarantees.
* **Chores**
  * .gitignore updated to ignore local tooling artifacts and PDF files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->