### PR TITLE
Tighten implementation plan, add Issue 02b, formalize data/ tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,7 +41,9 @@ pip-wheel-metadata/
 .idea/
 .DS_Store
 Thumbs.db
+*:Zone.Identifier
 
 # Local datasets
-databento.zip
+data/*
+!data/README.md
 *.pdf

--- a/GITHUB_ISSUES.md
+++ b/GITHUB_ISSUES.md
@@ -57,6 +57,42 @@ See Gate B.
 
 ---
 
+## Issue 02b — Databento parquet loader
+**Branch:** `feat/02b-databento-loader`
+**Gate:** B
+
+### Goal
+Load local databento 1-minute OHLCV parquet files into the repository's
+canonical market-data contract so side-information experiments can run on the
+paper's exact contract (ES) at 1-minute frequency.
+
+### Tasks
+- add `pyarrow` to runtime dependencies in `pyproject.toml` and `requirements.txt`
+- implement `load_databento_parquet(path, *, symbol=None, spec=None)` in `src/hft_hmm/data.py` that:
+  - reads the parquet file via pandas/pyarrow
+  - promotes the `ts_event` UTC DatetimeIndex to a `timestamp` column
+  - maps `close` → `price` and preserves `volume`
+  - drops databento metadata columns (`rtype`, `publisher_id`, `instrument_id`, `symbol`)
+  - optionally filters by `symbol` value before dropping it (files may contain multiple continuous-contract rolls)
+  - routes through `validate_market_data` so the existing contract tests apply uniformly
+- export the new loader from `hft_hmm/__init__.py`
+- add a small parquet fixture (one or two days, single symbol) under `tests/fixtures/`, keeping it under ~200 KB
+- add unit tests covering: happy path, missing `close` / `ts_event`, symbol filter, and malformed metadata
+
+### Deliverables
+- `load_databento_parquet` in `src/hft_hmm/data.py`
+- `pyarrow` added to runtime deps
+- parquet fixture under `tests/fixtures/`
+- additions to `tests/test_data_io.py`
+
+### Acceptance notes
+See Gate B. The loader must produce a DataFrame indistinguishable from the
+CSV loader's output once run through `validate_market_data`, so downstream
+code does not need a source-specific branch. Large parquet files live under
+`data/databento/` and are not tracked in git.
+
+---
+
 ## Issue 03 — Return preprocessing and sampling frequency utilities
 **Branch:** `feat/03-return-preprocessing`
 **Gate:** B
@@ -133,11 +169,13 @@ Wrap `hmmlearn` cleanly so the model is easy to inspect and test.
 - implement fit / predict / predict_proba interface
 - expose learned means, variances, transition matrix, initial distribution
 - add deterministic random state support
-- document which parts are delegated to `hmmlearn`
+- support an `init_from_plr=True` option that seeds means, variances, and state sequence from Issue 05's PLR output, matching the paper's initialization strategy
+- document which parts are delegated to `hmmlearn` and which are engineering wrappers around it
 
 ### Deliverables
 - `models/gaussian_hmm.py`
 - synthetic regime-switching tests
+- a test that `init_from_plr=True` produces reproducible fits on a fixed fixture
 
 ### Acceptance notes
 See Gate C.
@@ -174,14 +212,15 @@ See Gate D.
 Implement the forward recursion used for filtering and expected return prediction.
 
 ### Tasks
-- implement normalized forward recursion
-- use log-safe computations where needed
-- compute filtering probabilities over states
-- expose expected return from probabilities and state means
+- implement the forward recursion in log-space using log-sum-exp stabilization
+- return filtering probabilities `p(m_t | Δy_{1:t})` normalized at every step
+- expose expected return `E[Δy_{t+1} | Δy_{1:t}]` from filtering probabilities and state means
+- add a no-underflow regression test on a synthetic sequence of at least 5,000 steps
 
 ### Deliverables
 - `inference/forward_filter.py`
 - toy-system tests with normalization checks
+- long-sequence stability test
 
 ### Acceptance notes
 See Gate D.
@@ -215,17 +254,21 @@ See Gate E.
 **Gate:** E
 
 ### Goal
-Create reusable evaluation functions and report-ready summaries.
+Create reusable evaluation functions and report-ready summaries, reported in
+both pre-cost and post-cost form so comparison to the paper's pre-cost
+Sharpe is honest.
 
 ### Tasks
 - implement cumulative return
-- implement Sharpe ratio
+- implement Sharpe ratio in both pre-cost and post-cost modes with an explicit cost model (basis points per turnover)
 - implement drawdown and hit rate
-- generate compact summary DataFrame
+- generate compact summary DataFrame that labels each row pre-cost or post-cost
+- document the cost model and default assumptions in the module docstring
 
 ### Deliverables
 - `evaluation/metrics.py`
-- metric edge-case tests
+- metric edge-case tests (zero-variance, constant signal, single-period)
+- a test that post-cost Sharpe equals pre-cost Sharpe when cost = 0
 
 ### Acceptance notes
 See Gate E.
@@ -237,16 +280,22 @@ See Gate E.
 **Gate:** F
 
 ### Goal
-Reflect the paper's rolling retraining setup in a reproducible experiment.
+Reflect the paper's retraining setup in a reproducible experiment. The
+paper's scheme is a fixed-length training window followed by a forecast
+period, so the default here matches that: train on the most recent `H` days,
+forecast one step ahead over the subsequent `T` days, then advance the
+window and retrain.
 
 ### Tasks
-- implement walk-forward training loop
-- support configurable window length and retrain frequency
-- log chosen parameters and outputs per window
+- implement a walk-forward loop with the default "train H days → forecast T days → advance" scheme
+- parameterize window length `H`, forecast horizon `T`, and retrain frequency (default: retrain once per forecast period)
+- assert at the boundary of every window that no timestamp in the training slice is ≥ the first forecast timestamp
+- log per-window: window index, train/test time ranges, chosen `K`, log-likelihood, and metrics summary
 
 ### Deliverables
 - `experiments/walk_forward.py`
-- small integration test with fixture data
+- small integration test with fixture data covering at least two windows
+- an explicit no-leakage test that fails if the loop accidentally trains on future data
 
 ### Acceptance notes
 See Gate F.
@@ -258,16 +307,25 @@ See Gate F.
 **Gate:** F
 
 ### Goal
-Make experiment settings explicit and saved.
+Make experiment settings explicit and saved. The reproducibility contract is
+that any run can be re-executed from its saved config alone.
 
 ### Tasks
-- create typed configuration object or YAML-based config
-- log dataset, frequency, K, seed, windows, feature params
-- save experiment summaries to disk
+- create a typed configuration object with YAML (de)serialization
+- cover dataset, frequency, `K`, seed, walk-forward windows, feature params, and cost model
+- define the run-artifact layout under `runs/<run_id>/`:
+  - `config.yaml` (resolved, deterministic serialization)
+  - `metrics.json` (summary metrics, pre- and post-cost)
+  - `figures/` (any plots produced)
+  - `log.jsonl` (per-window log entries, one JSON object per line)
+- `run_id = sha256(resolved_config_yaml)[:12]` so identical configs map to identical run ids
+- add `scripts/repro.py <config.yaml>` that loads a saved config and re-executes the run end to end
 
 ### Deliverables
 - `config/experiment_config.py`
+- `scripts/repro.py`
 - config validation tests
+- a round-trip test: run on fixture → re-run via `repro.py` → metrics match bit-for-bit
 
 ### Acceptance notes
 See Gate F.
@@ -301,16 +359,21 @@ See Gate G.
 **Gate:** G
 
 ### Goal
-Implement the second side-information predictor.
+Implement the second side-information predictor. The paper's seasonality
+spline is defined over Chicago local time (CME exchange TZ), so the feature
+must convert away from the loader's canonical UTC before bucketing.
 
 ### Tasks
-- map timestamps to time-of-day index
-- compute intraday seasonal buckets or normalized index
-- expose feature series for spline fitting
+- convert timestamps from UTC to an exchange-local timezone (default `America/Chicago` for ES; configurable for other venues)
+- map converted timestamps to a time-of-day index
+- compute intraday seasonal buckets or a normalized index suitable for spline input
+- expose the feature as a pd.Series aligned with the price series
+- add a test that a known 09:30 Chicago timestamp maps to the same bucket across daylight-saving transitions
 
 ### Deliverables
 - `features/seasonality.py`
 - feature construction tests
+- explicit TZ-conversion test (includes a DST boundary)
 
 ### Acceptance notes
 See Gate G.
@@ -345,16 +408,26 @@ See Gate G.
 
 ### Goal
 Approximate the paper's idea that transitions depend on side information.
+Two routes are offered: the paper's **spline-bucketed transition matrix** is
+the primary deliverable; a **softmax-conditioned** variant is an optional
+stretch for comparison.
 
-### Tasks
-- define transition model `P(m_t | m_{t-1}, x_t)` using logistic or softmax regression
-- train transition conditioner on inferred or decoded states
-- expose time-varying transition probabilities
-- document deviation from full IOHMM learning
+### Tasks (primary — bucketed-A route)
+- discretize each spline predictor into `R` buckets using the spline's roots as boundaries (paper uses `R = 5` for the two splines in Fig. 5)
+- align each side-information value `x_t` with the corresponding return and assign it to a bucket
+- train a separate transition matrix `A_r` per bucket via Baum-Welch on the concatenated per-bucket data
+- expose a time-varying transition probability lookup `A(x_t)` that selects the matrix for the current bucket
+- document the concatenation shortcut as an approximation to the paper's formulation
+
+### Tasks (optional stretch — softmax route)
+- implement `P(m_t | m_{t-1}, x_t)` as a softmax-conditioned model fitted to decoded or inferred states
+- compare against the bucketed-A route on a small fixture
 
 ### Deliverables
-- `models/iohmm_approx.py`
-- normalization and deterministic tests
+- `models/iohmm_approx.py` containing the bucketed-A implementation
+- normalization tests: every `A_r` row sums to 1 within tolerance
+- a deterministic fit test on a synthetic fixture
+- a short note in the module docstring describing deviations from the paper (concatenation, finite bucket count, optional softmax variant)
 
 ### Acceptance notes
 See Gate H.

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -52,6 +52,17 @@ The repo must support the course goal of simulating some results of the paper an
   - `docs/NN-short-name`
   - `fix/NN-short-name`
 
+### 2.5 Scope exclusions
+These parts of the original paper are intentionally out of scope for the
+coursework replication. They are listed here so the grader does not mistake
+their absence for oversight.
+
+- **MCMC parameter estimation.** The paper fits Θ by both Baum-Welch and Metropolis-Hastings. This repo uses only Baum-Welch.
+- **MCMC bridge sampling for model selection.** The paper picks `K` using cross-validation, AIC/BIC, and marginal likelihood via MCMC bridge sampling. This repo uses only cross-validation plus AIC/BIC.
+- **Asynchronous IOHMM.** The paper sketches an asynchronous variant for mixed-frequency inputs. This repo implements only the synchronous IOHMM approximation.
+- **Multi-security / portfolio backtest.** Evaluation is single-security (ES or an equivalent proxy). No cross-asset construction.
+- **Production execution concerns.** No latency modeling, slippage beyond a flat cost-per-turnover, venue microstructure, or order-book effects.
+
 ---
 
 ## 3. Acceptance gates
@@ -84,11 +95,14 @@ A gate passes only when all listed conditions are satisfied.
 ---
 
 ## Gate B — Data contract and preprocessing
-**Covers:** Issues 02, 03, 04
+**Covers:** Issues 02, 02b, 03, 04
 
 ### Must pass
 - Data loading accepts a documented schema.
 - Timestamp parsing is validated.
+- At least one CSV / yfinance loader and one databento parquet loader exist and both route through the same validation path.
+- The databento parquet loader maps `ts_event` → `timestamp`, `close` → `price`, and filters by `symbol` when requested.
+- The replication dataset decision (yfinance daily for development, databento 1-minute ES for paper-replication runs) is documented in the repo.
 - Log returns are computed correctly.
 - Resampling preserves time order and documents frequency assumptions.
 - Duplicate timestamps and missing values are handled explicitly.
@@ -98,6 +112,7 @@ A gate passes only when all listed conditions are satisfied.
 ### Evidence expected in PR review
 - unit tests on synthetic price data
 - tests for malformed input
+- parquet fixture + loader test exercising the databento path
 - one example showing daily and intraday preprocessing
 
 ---
@@ -134,11 +149,12 @@ A gate passes only when all listed conditions are satisfied.
 - AIC and BIC calculations are tested.
 - Forward filtering returns normalized state probabilities at every time step.
 - Expected return from filtering probabilities and state means is exposed as an API.
-- Numerical stability is addressed and documented.
+- The forward recursion runs in log-space with log-sum-exp stabilization and does not underflow on long sequences.
 
 ### Evidence expected in PR review
 - tests verifying normalization
 - tests for AIC/BIC formulas
+- a no-underflow test on a synthetic sequence of at least 5,000 steps
 - one toy two-state example with known behavior
 
 ---
@@ -152,15 +168,17 @@ A gate passes only when all listed conditions are satisfied.
 - No look-ahead leakage exists in the signal path.
 - Evaluation functions exist for at least:
   - cumulative return
-  - Sharpe ratio
+  - Sharpe ratio (reported in both pre-cost and post-cost form)
   - drawdown
   - hit rate
+- The cost model (basis points per turnover) is documented and post-cost equals pre-cost when cost = 0.
 - Metric edge cases are tested.
 
 ### Evidence expected in PR review
 - alignment tests
 - zero-variance metric test
-- example summary table from a small experiment
+- pre-cost vs post-cost parity test at cost = 0
+- example summary table from a small experiment, labeled pre- and post-cost
 
 ---
 
@@ -168,21 +186,21 @@ A gate passes only when all listed conditions are satisfied.
 **Covers:** Issues 11, 12
 
 ### Must pass
-- A rolling or walk-forward training loop exists.
-- Window size and retraining frequency are configurable.
-- Future data is never used during fitting.
-- Every experiment saves:
-  - dataset info
-  - frequency
-  - seed
-  - K
-  - feature settings
-  - metrics summary
-- Results can be reproduced from a saved configuration.
+- A walk-forward training loop exists with the default scheme: train on the most recent `H` days → forecast one step ahead over the subsequent `T` days → advance the window and retrain.
+- `H`, `T`, and retrain frequency are configurable; the default retrains once per forecast period.
+- Future data is never used during fitting, verified by an explicit boundary assertion inside the loop.
+- Each run produces a `runs/<run_id>/` directory containing:
+  - `config.yaml` (resolved, deterministic serialization)
+  - `metrics.json` (pre- and post-cost summary)
+  - `figures/` (any plots)
+  - `log.jsonl` (one JSON entry per window)
+- `run_id = sha256(resolved_config_yaml)[:12]` so identical configs map to identical artifact directories.
+- `scripts/repro.py <config.yaml>` re-executes a run end to end and the resulting metrics match bit-for-bit.
 
 ### Evidence expected in PR review
-- one integration test on a small fixture
-- saved config artifact example
+- integration test on a fixture covering at least two windows
+- saved config + run artifact example
+- round-trip reproducibility test via `scripts/repro.py`
 - explicit no-leakage review notes
 
 ---
@@ -208,20 +226,19 @@ A gate passes only when all listed conditions are satisfied.
 **Covers:** Issues 16, 17
 
 ### Must pass
-- The repo contains either:
-  1. a clearly labeled **approximate** transition-conditioning implementation, or
-  2. a clearly labeled **full** IOHMM implementation
-- Transition probabilities vary with side information and remain normalized.
+- The repo contains a clearly labeled **approximate** transition-conditioning implementation following the paper's spline-bucketed approach (discretize each spline into buckets using its roots as boundaries; train a separate transition matrix per bucket).
+- A softmax-conditioned variant may exist as an optional stretch for comparison; if present it is labeled as an engineering approximation rather than a paper-faithful route.
+- Transition probabilities vary with side information and remain normalized per row.
 - The experiment compares:
   - baseline HMM
   - volatility-enhanced version
   - seasonality-enhanced version
-- Deviations from the paper are explicitly documented.
+- Deviations from the paper — concatenation shortcut, finite bucket count, any softmax variant — are explicitly documented in the module docstring.
 
 ### Evidence expected in PR review
-- tests for shape and normalization
+- tests for shape and per-row normalization of every per-bucket transition matrix
 - one experiment script producing comparison outputs
-- written note stating whether the implementation is full IOHMM or approximation
+- written note naming the approximation route(s) implemented and listing deviations from the paper
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ This keeps the repository honest: CI already validates imports, formatting, lint
 
 ## Data Note
 
-The local archive `databento.zip` is intentionally excluded from version control because it exceeds GitHub's standard repository file size limits and should not be committed directly.
+Raw datasets live under `data/` and are excluded from version control because they exceed GitHub's repository size limits. See [`data/README.md`](data/README.md) for the expected layout, schema, and acquisition instructions. Small fixtures used by the test suite live under `tests/fixtures/` instead.
 
 ## License
 

--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,39 @@
+# Local data directory
+
+This directory holds large raw datasets used during development and experiments. **Nothing in here is tracked in git** — the contents exceed GitHub's repository size limits and are not meant to be versioned alongside the code. The `.gitignore` excludes everything except this README.
+
+## Layout
+
+```
+data/
+├── README.md                 # (this file, tracked)
+├── databento.zip             # full databento download archive (not tracked)
+└── databento/
+    └── databento/            # extracted parquet files (not tracked)
+        ├── ES_c_0_ohlcv-1m_2019-01-01_2024-12-31.parquet
+        ├── NQ_c_0_ohlcv-1m_2019-01-01_2024-12-31.parquet
+        ├── ...
+```
+
+## Contents
+
+- **`databento/databento/*.parquet`** — 1-minute OHLCV bars for ~29 continuous-contract futures (ES, NQ, RTY, YM, CL, GC, 6E, ZN, etc.) covering 2019-01-01 through 2024-12-30 in UTC. The primary replication target is `ES_c_0_ohlcv-1m_2019-01-01_2024-12-31.parquet` (e-mini S&P500 continuous contract).
+- **`databento.zip`** — the original archive the parquet files were extracted from.
+
+## Schema (databento parquet)
+
+- Index: `ts_event` (tz-aware UTC `DatetimeIndex`)
+- Columns: `rtype`, `publisher_id`, `instrument_id`, `open`, `high`, `low`, `close`, `volume`, `symbol`
+
+The project's canonical contract (`MarketDataSpec` in `src/hft_hmm/data.py`) is `timestamp` / `price` / `volume`. Issue 02b adds a loader that maps `ts_event` → `timestamp`, `close` → `price`, and preserves `volume`.
+
+## Acquisition
+
+The databento files were exported from [databento.com](https://databento.com) using a continuous-contract dataset definition. To reproduce, either:
+
+- copy the archive from wherever it is stored locally, or
+- re-export from databento with the same symbols, frequency (`ohlcv-1m`), and date range (`2019-01-01` to `2024-12-31`).
+
+## Test fixtures
+
+Unit tests must not depend on anything in `data/`. Small, committed fixtures live under `tests/fixtures/` and should be kept to tens of KB. Issue 02b adds a compact single-day parquet fixture for the databento loader tests.


### PR DESCRIPTION
## Summary
- Adds **Issue 02b** — databento parquet loader so ES 1-min data can reach the replication pipeline
- Pins the paper's **spline-bucketed transition approximation** as the primary Issue 16 deliverable (softmax demoted to optional stretch)
- Tightens several issues and gate acceptance lines: walk-forward scheme, run-artifact tree + `scripts/repro.py`, log-space filtering with long-sequence underflow test, pre/post-cost Sharpe, Chicago-TZ seasonality, PLR-seeded HMM init
- Adds a **Scope Exclusions** section to the plan so dropped paper components (MCMC, async IOHMM, multi-security) are explicit decisions rather than silent omissions
- Formalizes **data/ tracking policy**: `.gitignore` now excludes `data/*` with an exception for `data/README.md`; the README documents layout, schema, and acquisition. Also ignores WSL `*:Zone.Identifier` artifacts

No code changes — documentation and repo-policy only.

## Test plan
- [x] All 21 issues (01–20 + 02b) still map to exactly one gate each (verified via grep on `**Covers:**` lines)
- [x] `git check-ignore` confirms: `data/databento.zip`, `*.parquet`, and `:Zone.Identifier` files are ignored; `data/README.md` is tracked
- [x] No modifications to `src/` or `tests/` — existing test suite is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated data directory documentation with expected layout, schema, and acquisition instructions.
  * Added comprehensive guide for managing local development datasets.

* **Chores**
  * Updated `.gitignore` to properly exclude data directory while preserving documentation files.
  * Updated project planning documents with requirements for data loading capabilities and experimental workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->