### PR TITLE
feat(04): state grid and paper reference helpers

### DIFF
--- a/src/hft_hmm/__init__.py
+++ b/src/hft_hmm/__init__.py
@@ -1,6 +1,18 @@
 """Core package for the HMM trading project."""
 
 from hft_hmm._version import __version__
+from hft_hmm.core import (
+    ALL_CATEGORIES,
+    ENGINEERING_APPROXIMATION,
+    EVALUATION_LAYER,
+    PAPER_FAITHFUL,
+    PaperReference,
+    StateGrid,
+    default_labels,
+    linear_grid,
+    module_category,
+    reference,
+)
 from hft_hmm.data import (
     MarketDataSpec,
     MarketDataValidationError,
@@ -13,16 +25,26 @@ from hft_hmm.preprocessing import compute_log_returns, resample_prices, train_te
 from hft_hmm.project import PROJECT_NAME, ProjectInfo, get_project_info
 
 __all__ = [
+    "ALL_CATEGORIES",
+    "ENGINEERING_APPROXIMATION",
+    "EVALUATION_LAYER",
+    "PAPER_FAITHFUL",
     "PROJECT_NAME",
-    "ProjectInfo",
     "MarketDataSpec",
     "MarketDataValidationError",
+    "PaperReference",
+    "ProjectInfo",
+    "StateGrid",
     "__version__",
     "compute_log_returns",
+    "default_labels",
     "get_project_info",
+    "linear_grid",
     "load_csv_market_data",
     "load_databento_parquet",
     "load_yfinance_market_data",
+    "module_category",
+    "reference",
     "resample_prices",
     "train_test_split_time",
     "validate_market_data",

--- a/src/hft_hmm/core/__init__.py
+++ b/src/hft_hmm/core/__init__.py
@@ -1,0 +1,25 @@
+"""Cross-cutting primitives: paper references, taxonomy constants, state grids."""
+
+from hft_hmm.core.references import (
+    ALL_CATEGORIES,
+    ENGINEERING_APPROXIMATION,
+    EVALUATION_LAYER,
+    PAPER_FAITHFUL,
+    PaperReference,
+    module_category,
+    reference,
+)
+from hft_hmm.core.state_metadata import StateGrid, default_labels, linear_grid
+
+__all__ = [
+    "ALL_CATEGORIES",
+    "ENGINEERING_APPROXIMATION",
+    "EVALUATION_LAYER",
+    "PAPER_FAITHFUL",
+    "PaperReference",
+    "StateGrid",
+    "default_labels",
+    "linear_grid",
+    "module_category",
+    "reference",
+]

--- a/src/hft_hmm/core/references.py
+++ b/src/hft_hmm/core/references.py
@@ -1,0 +1,70 @@
+"""Paper reference helpers and module taxonomy constants.
+
+Every module in this repository belongs to one of three categories declared via
+the module-level ``__category__`` attribute:
+
+- ``PAPER_FAITHFUL`` — direct reproduction of a construction from
+  Christensen/Turner/Godsill (2020).
+- ``ENGINEERING_APPROXIMATION`` — pragmatic substitute where an exact
+  reproduction is out of scope for the coursework.
+- ``EVALUATION_LAYER`` — metrics, plotting, or experiment utilities that do not
+  model the data-generating process directly.
+
+The ``PaperReference`` dataclass and ``reference()`` factory attach structured
+pointers to a paper section alongside a short topic label, so module docstrings
+and tests can cite the paper without free-form strings drifting out of sync.
+
+References: Engineering utility
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import ModuleType
+from typing import Final
+
+PAPER_FAITHFUL: Final[str] = "paper-faithful"
+ENGINEERING_APPROXIMATION: Final[str] = "engineering-approximation"
+EVALUATION_LAYER: Final[str] = "evaluation-layer"
+
+ALL_CATEGORIES: Final[frozenset[str]] = frozenset(
+    {PAPER_FAITHFUL, ENGINEERING_APPROXIMATION, EVALUATION_LAYER}
+)
+
+
+@dataclass(frozen=True)
+class PaperReference:
+    """Structured pointer to a section of the replicated paper."""
+
+    section: str
+    topic: str
+
+    def __str__(self) -> str:
+        return f"{self.section} — {self.topic}"
+
+
+def reference(section: str, topic: str) -> PaperReference:
+    """Create a ``PaperReference`` after validating both fields are non-empty."""
+    if not section or not section.strip():
+        raise ValueError("section must be a non-empty string.")
+    if not topic or not topic.strip():
+        raise ValueError("topic must be a non-empty string.")
+    return PaperReference(section=section.strip(), topic=topic.strip())
+
+
+def module_category(module: ModuleType) -> str | None:
+    """Return the declared ``__category__`` of ``module`` or ``None`` if absent.
+
+    Raises ``ValueError`` when the module declares a category outside
+    ``ALL_CATEGORIES``, so typos surface at import-test time rather than during
+    later review.
+    """
+    category = getattr(module, "__category__", None)
+    if category is None:
+        return None
+    if category not in ALL_CATEGORIES:
+        raise ValueError(
+            f"Module {module.__name__} declares unknown __category__ {category!r}; "
+            f"expected one of {sorted(ALL_CATEGORIES)}."
+        )
+    return category

--- a/src/hft_hmm/core/references.py
+++ b/src/hft_hmm/core/references.py
@@ -23,6 +23,8 @@ from dataclasses import dataclass
 from types import ModuleType
 from typing import Final, cast
 
+__category__ = "engineering-approximation"
+
 PAPER_FAITHFUL: Final[str] = "paper-faithful"
 ENGINEERING_APPROXIMATION: Final[str] = "engineering-approximation"
 EVALUATION_LAYER: Final[str] = "evaluation-layer"
@@ -62,6 +64,11 @@ def module_category(module: ModuleType) -> str | None:
     category = getattr(module, "__category__", None)
     if category is None:
         return None
+    if not isinstance(category, str):
+        raise ValueError(
+            f"Module {module.__name__} declares invalid __category__ {category!r}; "
+            "__category__ must be a string."
+        )
     if category not in ALL_CATEGORIES:
         raise ValueError(
             f"Module {module.__name__} declares unknown __category__ {category!r}; "

--- a/src/hft_hmm/core/references.py
+++ b/src/hft_hmm/core/references.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from types import ModuleType
-from typing import Final
+from typing import Final, cast
 
 PAPER_FAITHFUL: Final[str] = "paper-faithful"
 ENGINEERING_APPROXIMATION: Final[str] = "engineering-approximation"
@@ -67,4 +67,4 @@ def module_category(module: ModuleType) -> str | None:
             f"Module {module.__name__} declares unknown __category__ {category!r}; "
             f"expected one of {sorted(ALL_CATEGORIES)}."
         )
-    return category
+    return cast(str, category)

--- a/src/hft_hmm/core/state_metadata.py
+++ b/src/hft_hmm/core/state_metadata.py
@@ -1,0 +1,82 @@
+"""State-grid metadata used by the HMM baseline and downstream evaluators.
+
+A ``StateGrid`` fixes an ordering over hidden states together with their
+representative mean returns. Downstream modules (filtering, signal generation,
+plotting) can then refer to states by label rather than by integer index, and a
+single source of truth governs the ordering used for signed expected returns.
+
+References: Engineering utility
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class StateGrid:
+    """Immutable mapping from hidden-state index to label and mean return."""
+
+    k: int
+    means: np.ndarray
+    labels: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        if self.k < 2:
+            raise ValueError(f"StateGrid requires k >= 2, got {self.k}.")
+        if self.means.shape != (self.k,):
+            raise ValueError(f"means must have shape ({self.k},), got {self.means.shape}.")
+        if len(self.labels) != self.k:
+            raise ValueError(f"labels must have length {self.k}, got {len(self.labels)}.")
+        if len(set(self.labels)) != self.k:
+            raise ValueError("labels must be unique.")
+
+    def label(self, index: int) -> str:
+        """Return the label for state ``index``."""
+        if not 0 <= index < self.k:
+            raise IndexError(f"state index {index} out of range for k={self.k}.")
+        return self.labels[index]
+
+    def index(self, label: str) -> int:
+        """Return the state index for ``label``."""
+        try:
+            return self.labels.index(label)
+        except ValueError as exc:
+            raise KeyError(f"unknown state label {label!r}.") from exc
+
+
+def default_labels(k: int) -> tuple[str, ...]:
+    """Return semantic labels for small ``k`` or generic ``state_i`` labels.
+
+    ``k == 2`` maps to ``("down", "up")``, ``k == 3`` maps to
+    ``("down", "flat", "up")``, and larger grids use ``("state_0", ...,
+    "state_{k-1}")`` to avoid implying structure the model has not recovered.
+    """
+    if k < 2:
+        raise ValueError(f"default_labels requires k >= 2, got {k}.")
+    if k == 2:
+        return ("down", "up")
+    if k == 3:
+        return ("down", "flat", "up")
+    return tuple(f"state_{i}" for i in range(k))
+
+
+def linear_grid(k: int, min_return: float, max_return: float) -> StateGrid:
+    """Construct a ``StateGrid`` with means evenly spaced over a return range.
+
+    The grid ordering is monotonically increasing in the mean return, so the
+    lowest-index state is the most bearish and the highest-index state is the
+    most bullish. Default semantic labels are assigned via ``default_labels``.
+    """
+    if k < 2:
+        raise ValueError(f"linear_grid requires k >= 2, got {k}.")
+    if not min_return < max_return:
+        raise ValueError(
+            f"min_return must be strictly less than max_return; "
+            f"got min_return={min_return}, max_return={max_return}."
+        )
+    means = np.linspace(min_return, max_return, num=k)
+    labels = default_labels(k)
+    return StateGrid(k=k, means=means, labels=labels)

--- a/src/hft_hmm/core/state_metadata.py
+++ b/src/hft_hmm/core/state_metadata.py
@@ -24,14 +24,17 @@ class StateGrid:
     labels: tuple[str, ...]
 
     def __post_init__(self) -> None:
+        arr = np.asarray(self.means, dtype=float).copy()
         if self.k < 2:
             raise ValueError(f"StateGrid requires k >= 2, got {self.k}.")
-        if self.means.shape != (self.k,):
-            raise ValueError(f"means must have shape ({self.k},), got {self.means.shape}.")
+        if arr.shape != (self.k,):
+            raise ValueError(f"means must have shape ({self.k},), got {arr.shape}.")
         if len(self.labels) != self.k:
             raise ValueError(f"labels must have length {self.k}, got {len(self.labels)}.")
         if len(set(self.labels)) != self.k:
             raise ValueError("labels must be unique.")
+        arr.setflags(write=False)
+        object.__setattr__(self, "means", arr)
 
     def label(self, index: int) -> str:
         """Return the label for state ``index``."""
@@ -72,11 +75,26 @@ def linear_grid(k: int, min_return: float, max_return: float) -> StateGrid:
     """
     if k < 2:
         raise ValueError(f"linear_grid requires k >= 2, got {k}.")
+    if not (np.isfinite(min_return) and np.isfinite(max_return)):
+        raise ValueError(
+            "linear_grid requires finite min_return and max_return; "
+            f"got k={k}, min_return={min_return}, max_return={max_return}."
+        )
     if not min_return < max_return:
         raise ValueError(
             f"min_return must be strictly less than max_return; "
             f"got min_return={min_return}, max_return={max_return}."
         )
     means = np.linspace(min_return, max_return, num=k)
+    if not np.all(np.isfinite(means)):
+        raise ValueError(
+            "linear_grid produced non-finite means; "
+            f"got k={k}, min_return={min_return}, max_return={max_return}, means={means!r}."
+        )
+    if not np.all(np.diff(means) > 0):
+        raise ValueError(
+            "linear_grid produced non-increasing means; "
+            f"got k={k}, min_return={min_return}, max_return={max_return}, means={means!r}."
+        )
     labels = default_labels(k)
     return StateGrid(k=k, means=means, labels=labels)

--- a/src/hft_hmm/data.py
+++ b/src/hft_hmm/data.py
@@ -1,4 +1,9 @@
-"""Data loading and validation utilities for market time series."""
+"""Data loading and validation utilities for market time series.
+
+Engineering utility — provides the canonical ``timestamp`` / ``price`` /
+``volume`` contract used by every loader and downstream consumer. See
+``DATA_REFERENCE`` for the paper pointer that motivates the aggregation step.
+"""
 
 from __future__ import annotations
 
@@ -7,6 +12,11 @@ from pathlib import Path
 from typing import Final
 
 import pandas as pd
+
+from hft_hmm.core.references import ENGINEERING_APPROXIMATION, PaperReference, reference
+
+__category__: Final[str] = ENGINEERING_APPROXIMATION
+DATA_REFERENCE: Final[PaperReference] = reference("§7", "1-minute ES aggregation")
 
 REQUIRED_COLUMNS: Final[tuple[str, str]] = ("timestamp", "price")
 OPTIONAL_COLUMNS: Final[tuple[str, ...]] = ("volume",)

--- a/src/hft_hmm/preprocessing.py
+++ b/src/hft_hmm/preprocessing.py
@@ -6,8 +6,14 @@ support data ingestion and feature engineering pipelines.
 
 from __future__ import annotations
 
+from typing import Final
+
 import numpy as np
 import pandas as pd
+
+from hft_hmm.core.references import ENGINEERING_APPROXIMATION
+
+__category__: Final[str] = ENGINEERING_APPROXIMATION
 
 
 def compute_log_returns(prices: pd.Series) -> pd.Series:

--- a/src/hft_hmm/project.py
+++ b/src/hft_hmm/project.py
@@ -1,6 +1,11 @@
 """Project-level metadata helpers for scaffolding and tooling."""
 
 from dataclasses import dataclass
+from typing import Final
+
+from hft_hmm.core.references import ENGINEERING_APPROXIMATION
+
+__category__: Final[str] = ENGINEERING_APPROXIMATION
 
 PROJECT_NAME = "hft-hmm"
 

--- a/tests/test_core_references.py
+++ b/tests/test_core_references.py
@@ -79,6 +79,13 @@ def test_module_category_rejects_unknown_value():
         module_category(module)
 
 
+def test_module_category_rejects_non_string_value():
+    module = types.ModuleType("fake_module")
+    module.__category__ = []
+    with pytest.raises(ValueError, match="must be a string"):
+        module_category(module)
+
+
 def test_existing_modules_declare_valid_categories():
     from hft_hmm import data, preprocessing, project
 

--- a/tests/test_core_references.py
+++ b/tests/test_core_references.py
@@ -1,0 +1,87 @@
+"""Tests for the paper reference helpers and module category registry."""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+
+from hft_hmm.core.references import (
+    ALL_CATEGORIES,
+    ENGINEERING_APPROXIMATION,
+    EVALUATION_LAYER,
+    PAPER_FAITHFUL,
+    PaperReference,
+    module_category,
+    reference,
+)
+
+
+def test_category_constants_distinct_and_covered():
+    assert ALL_CATEGORIES == frozenset(
+        {PAPER_FAITHFUL, ENGINEERING_APPROXIMATION, EVALUATION_LAYER}
+    )
+    assert len(ALL_CATEGORIES) == 3
+
+
+def test_reference_factory_produces_paper_reference():
+    ref = reference("§3.2", "forward filtering")
+    assert isinstance(ref, PaperReference)
+    assert ref.section == "§3.2"
+    assert ref.topic == "forward filtering"
+
+
+def test_reference_strips_whitespace():
+    ref = reference("  §3  ", "  topic  ")
+    assert ref.section == "§3"
+    assert ref.topic == "topic"
+
+
+def test_reference_str_format():
+    ref = reference("§3.2", "forward filtering")
+    assert str(ref) == "§3.2 — forward filtering"
+
+
+@pytest.mark.parametrize(
+    "section,topic",
+    [("", "topic"), ("   ", "topic"), ("§3", ""), ("§3", "   ")],
+)
+def test_reference_rejects_empty_fields(section, topic):
+    with pytest.raises(ValueError):
+        reference(section, topic)
+
+
+def test_paper_reference_is_frozen():
+    ref = reference("§3", "t")
+    with pytest.raises(AttributeError):
+        ref.section = "§4"  # type: ignore[misc]
+
+
+def test_module_category_missing_returns_none():
+    module = types.ModuleType("fake_module")
+    assert module_category(module) is None
+
+
+@pytest.mark.parametrize(
+    "category",
+    [PAPER_FAITHFUL, ENGINEERING_APPROXIMATION, EVALUATION_LAYER],
+)
+def test_module_category_valid(category):
+    module = types.ModuleType("fake_module")
+    module.__category__ = category
+    assert module_category(module) == category
+
+
+def test_module_category_rejects_unknown_value():
+    module = types.ModuleType("fake_module")
+    module.__category__ = "unknown-category"
+    with pytest.raises(ValueError, match="unknown __category__"):
+        module_category(module)
+
+
+def test_existing_modules_declare_valid_categories():
+    from hft_hmm import data, preprocessing, project
+
+    for module in (data, preprocessing, project):
+        category = module_category(module)
+        assert category in ALL_CATEGORIES, f"{module.__name__} missing __category__"

--- a/tests/test_state_metadata.py
+++ b/tests/test_state_metadata.py
@@ -1,0 +1,107 @@
+"""Tests for state-grid metadata helpers."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from hft_hmm.core.state_metadata import StateGrid, default_labels, linear_grid
+
+
+def test_default_labels_k2():
+    assert default_labels(2) == ("down", "up")
+
+
+def test_default_labels_k3():
+    assert default_labels(3) == ("down", "flat", "up")
+
+
+@pytest.mark.parametrize("k", [4, 5, 8])
+def test_default_labels_generic(k):
+    labels = default_labels(k)
+    assert labels == tuple(f"state_{i}" for i in range(k))
+    assert len(labels) == k
+    assert len(set(labels)) == k
+
+
+def test_default_labels_rejects_small_k():
+    with pytest.raises(ValueError, match="k >= 2"):
+        default_labels(1)
+
+
+@pytest.mark.parametrize("k", [2, 3, 5])
+def test_linear_grid_monotone_increasing(k):
+    grid = linear_grid(k, -0.01, 0.01)
+    assert grid.k == k
+    assert grid.means.shape == (k,)
+    assert np.all(np.diff(grid.means) > 0)
+    assert grid.means[0] == pytest.approx(-0.01)
+    assert grid.means[-1] == pytest.approx(0.01)
+
+
+def test_linear_grid_round_trip_label_index():
+    grid = linear_grid(3, -0.01, 0.01)
+    for i, expected_label in enumerate(("down", "flat", "up")):
+        assert grid.label(i) == expected_label
+        assert grid.index(expected_label) == i
+
+
+def test_linear_grid_uses_default_labels():
+    assert linear_grid(2, -0.01, 0.01).labels == ("down", "up")
+    assert linear_grid(3, -0.01, 0.01).labels == ("down", "flat", "up")
+    assert linear_grid(5, -0.02, 0.02).labels == tuple(f"state_{i}" for i in range(5))
+
+
+def test_linear_grid_rejects_small_k():
+    with pytest.raises(ValueError, match="k >= 2"):
+        linear_grid(1, -0.01, 0.01)
+
+
+def test_linear_grid_rejects_inverted_range():
+    with pytest.raises(ValueError, match="strictly less than"):
+        linear_grid(3, 0.01, -0.01)
+
+
+def test_linear_grid_rejects_degenerate_range():
+    with pytest.raises(ValueError, match="strictly less than"):
+        linear_grid(3, 0.0, 0.0)
+
+
+def test_state_grid_is_frozen():
+    grid = linear_grid(2, -0.01, 0.01)
+    with pytest.raises(AttributeError):
+        grid.k = 3  # type: ignore[misc]
+
+
+def test_state_grid_label_out_of_range():
+    grid = linear_grid(2, -0.01, 0.01)
+    with pytest.raises(IndexError):
+        grid.label(2)
+    with pytest.raises(IndexError):
+        grid.label(-1)
+
+
+def test_state_grid_index_unknown_label():
+    grid = linear_grid(2, -0.01, 0.01)
+    with pytest.raises(KeyError):
+        grid.index("sideways")
+
+
+def test_state_grid_rejects_mismatched_means_shape():
+    with pytest.raises(ValueError, match="means must have shape"):
+        StateGrid(k=3, means=np.array([-0.01, 0.01]), labels=("a", "b", "c"))
+
+
+def test_state_grid_rejects_mismatched_labels_length():
+    with pytest.raises(ValueError, match="labels must have length"):
+        StateGrid(k=3, means=np.array([-0.01, 0.0, 0.01]), labels=("a", "b"))
+
+
+def test_state_grid_rejects_duplicate_labels():
+    with pytest.raises(ValueError, match="labels must be unique"):
+        StateGrid(k=3, means=np.array([-0.01, 0.0, 0.01]), labels=("a", "a", "b"))
+
+
+def test_state_grid_rejects_small_k():
+    with pytest.raises(ValueError, match="k >= 2"):
+        StateGrid(k=1, means=np.array([0.0]), labels=("x",))

--- a/tests/test_state_metadata.py
+++ b/tests/test_state_metadata.py
@@ -73,6 +73,19 @@ def test_state_grid_is_frozen():
         grid.k = 3  # type: ignore[misc]
 
 
+def test_state_grid_means_array_is_read_only():
+    grid = linear_grid(3, -0.01, 0.01)
+    with pytest.raises(ValueError):
+        grid.means[0] = 0.0
+
+
+def test_state_grid_means_defensive_copy_from_input_array():
+    means = np.array([-0.01, 0.0, 0.01], dtype=float)
+    grid = StateGrid(k=3, means=means, labels=("down", "flat", "up"))
+    means[0] = -1.0
+    assert grid.means[0] == pytest.approx(-0.01)
+
+
 def test_state_grid_label_out_of_range():
     grid = linear_grid(2, -0.01, 0.01)
     with pytest.raises(IndexError):


### PR DESCRIPTION
## Summary
- Introduce `src/hft_hmm/core/` subpackage with `PaperReference` dataclass, `reference()` factory, and taxonomy constants (`PAPER_FAITHFUL`, `ENGINEERING_APPROXIMATION`, `EVALUATION_LAYER`).
- Add `StateGrid` dataclass with label↔index round-trip plus `default_labels()` and `linear_grid()` factories for monotone mean-return grids.
- Tag existing modules (`data.py`, `preprocessing.py`, `project.py`) with `__category__` and demonstrate `reference()` via `DATA_REFERENCE` in `data.py`.

Closes Issue 04 (Gate B — state metadata and paper reference helpers).

## Test plan
- [x] `.venv/bin/python -m pytest` — 78 tests, 97% coverage
- [x] `.venv/bin/python -m ruff check .` — clean
- [x] `.venv/bin/python -m black --check .` — clean
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a module categorization system to organize code by type (paper-faithful, engineering approximation, evaluation layer).
  * Added StateGrid class for defining HMM state configurations with automatic label assignment and index lookup.
  * Added helper functions to create and validate state grids and paper reference objects.

* **Documentation**
  * Expanded module documentation with reference pointers to source materials.

* **Tests**
  * Added comprehensive test coverage for new state grid and categorization functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->