### PR TITLE
Issue 05: add piecewise linear regression baseline

### DIFF
--- a/src/hft_hmm/__init__.py
+++ b/src/hft_hmm/__init__.py
@@ -21,6 +21,12 @@ from hft_hmm.data import (
     load_yfinance_market_data,
     validate_market_data,
 )
+from hft_hmm.models import (
+    PLRBaselineResult,
+    PLRSegment,
+    PLRStateSummary,
+    fit_piecewise_linear_regression,
+)
 from hft_hmm.preprocessing import compute_log_returns, resample_prices, train_test_split_time
 from hft_hmm.project import PROJECT_NAME, ProjectInfo, get_project_info
 
@@ -33,11 +39,15 @@ __all__ = [
     "MarketDataSpec",
     "MarketDataValidationError",
     "PaperReference",
+    "PLRBaselineResult",
+    "PLRSegment",
+    "PLRStateSummary",
     "ProjectInfo",
     "StateGrid",
     "__version__",
     "compute_log_returns",
     "default_labels",
+    "fit_piecewise_linear_regression",
     "get_project_info",
     "linear_grid",
     "load_csv_market_data",

--- a/src/hft_hmm/models/__init__.py
+++ b/src/hft_hmm/models/__init__.py
@@ -1,0 +1,15 @@
+"""Model-building primitives used by the HMM trading project."""
+
+from hft_hmm.models.plr_baseline import (
+    PLRBaselineResult,
+    PLRSegment,
+    PLRStateSummary,
+    fit_piecewise_linear_regression,
+)
+
+__all__ = [
+    "PLRBaselineResult",
+    "PLRSegment",
+    "PLRStateSummary",
+    "fit_piecewise_linear_regression",
+]

--- a/src/hft_hmm/models/__init__.py
+++ b/src/hft_hmm/models/__init__.py
@@ -7,9 +7,12 @@ from hft_hmm.models.plr_baseline import (
     fit_piecewise_linear_regression,
 )
 
+from . import plr_baseline
+
 __all__ = [
     "PLRBaselineResult",
     "PLRSegment",
     "PLRStateSummary",
     "fit_piecewise_linear_regression",
+    "plr_baseline",
 ]

--- a/src/hft_hmm/models/plr_baseline.py
+++ b/src/hft_hmm/models/plr_baseline.py
@@ -1,0 +1,374 @@
+"""Piecewise linear regression baseline used for HMM initialization experiments.
+
+This module implements a deterministic top-down segmentation baseline inspired
+by the paper's PLR initialization idea. The implementation is an engineering
+approximation rather than a literal reproduction of the paper's full procedure.
+See ``PLR_BASELINE_REFERENCE`` for the paper pointer used in docstrings and
+review notes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import cache
+from typing import Final
+
+import numpy as np
+import pandas as pd
+from statsmodels.stats.stattools import durbin_watson
+
+from hft_hmm.core import (
+    ENGINEERING_APPROXIMATION,
+    PaperReference,
+    StateGrid,
+    default_labels,
+    reference,
+)
+
+__category__: Final[str] = ENGINEERING_APPROXIMATION
+PLR_BASELINE_REFERENCE: Final[PaperReference] = reference("§3.1", "PLR baseline")
+
+
+@dataclass(frozen=True)
+class PLRSegment:
+    """Chronological segment from a piecewise linear fit."""
+
+    segment_index: int
+    state_index: int
+    start_idx: int
+    end_idx: int
+    slope: float
+    intercept: float
+    residual_variance: float
+
+    def __post_init__(self) -> None:
+        if self.segment_index < 0:
+            raise ValueError("segment_index must be non-negative.")
+        if self.state_index < 0:
+            raise ValueError("state_index must be non-negative.")
+        if self.start_idx < 0:
+            raise ValueError("start_idx must be non-negative.")
+        if self.end_idx <= self.start_idx:
+            raise ValueError("end_idx must be strictly greater than start_idx.")
+        if self.residual_variance < 0.0:
+            raise ValueError("residual_variance must be non-negative.")
+
+    @property
+    def n_obs(self) -> int:
+        """Return the number of observations assigned to the segment."""
+        return self.end_idx - self.start_idx
+
+
+@dataclass(frozen=True)
+class PLRStateSummary:
+    """State-level summary derived from one chronological PLR segment."""
+
+    state_index: int
+    label: str
+    segment_index: int
+    start_idx: int
+    end_idx: int
+    slope: float
+    residual_variance: float
+
+    def __post_init__(self) -> None:
+        if self.state_index < 0:
+            raise ValueError("state_index must be non-negative.")
+        if not self.label:
+            raise ValueError("label must be non-empty.")
+        if self.segment_index < 0:
+            raise ValueError("segment_index must be non-negative.")
+        if self.end_idx <= self.start_idx:
+            raise ValueError("end_idx must be strictly greater than start_idx.")
+        if self.residual_variance < 0.0:
+            raise ValueError("residual_variance must be non-negative.")
+
+    @property
+    def n_obs(self) -> int:
+        """Return the number of observations assigned to the summarized state."""
+        return self.end_idx - self.start_idx
+
+
+@dataclass(frozen=True)
+class PLRBaselineResult:
+    """Immutable result of ``fit_piecewise_linear_regression``."""
+
+    segments: tuple[PLRSegment, ...]
+    state_summaries: tuple[PLRStateSummary, ...]
+    state_grid: StateGrid
+    breakpoints: tuple[int, ...]
+    fitted_values: np.ndarray
+    residuals: np.ndarray
+    segment_assignments: np.ndarray
+    state_sequence: np.ndarray
+    durbin_watson: float | None = None
+
+    def __post_init__(self) -> None:
+        fitted = np.asarray(self.fitted_values, dtype=float).copy()
+        residuals = np.asarray(self.residuals, dtype=float).copy()
+        segment_assignments = np.asarray(self.segment_assignments, dtype=int).copy()
+        state_sequence = np.asarray(self.state_sequence, dtype=int).copy()
+
+        n_obs = fitted.shape[0]
+        if fitted.ndim != 1:
+            raise ValueError("fitted_values must be one-dimensional.")
+        if residuals.shape != (n_obs,):
+            raise ValueError("residuals must have the same shape as fitted_values.")
+        if segment_assignments.shape != (n_obs,):
+            raise ValueError("segment_assignments must have the same shape as fitted_values.")
+        if state_sequence.shape != (n_obs,):
+            raise ValueError("state_sequence must have the same shape as fitted_values.")
+        if len(self.breakpoints) != len(self.segments):
+            raise ValueError("breakpoints must align one-to-one with segments.")
+        if self.breakpoints[-1] != n_obs:
+            raise ValueError("the final breakpoint must equal the number of observations.")
+        if len(self.state_summaries) != self.state_grid.k:
+            raise ValueError("state_summaries must align with state_grid.k.")
+
+        fitted.setflags(write=False)
+        residuals.setflags(write=False)
+        segment_assignments.setflags(write=False)
+        state_sequence.setflags(write=False)
+
+        object.__setattr__(self, "fitted_values", fitted)
+        object.__setattr__(self, "residuals", residuals)
+        object.__setattr__(self, "segment_assignments", segment_assignments)
+        object.__setattr__(self, "state_sequence", state_sequence)
+
+    @property
+    def state_means(self) -> np.ndarray:
+        """Return the ordered state-level slope proxies used for initialization."""
+        return self.state_grid.means
+
+    @property
+    def state_variances(self) -> np.ndarray:
+        """Return the ordered state-level residual variances."""
+        variances = np.array(
+            [summary.residual_variance for summary in self.state_summaries],
+            dtype=float,
+        )
+        variances.setflags(write=False)
+        return variances
+
+
+@dataclass(frozen=True)
+class _IntervalFit:
+    slope: float
+    intercept: float
+    sse: float
+
+
+def fit_piecewise_linear_regression(
+    series: pd.Series | np.ndarray,
+    n_segments: int,
+    *,
+    min_segment_length: int = 2,
+    compute_durbin_watson: bool = False,
+) -> PLRBaselineResult:
+    """Fit a deterministic piecewise linear regression baseline to ``series``.
+
+    The series is segmented chronologically using a greedy top-down split rule:
+    at each step, the current segment whose best admissible split yields the
+    largest reduction in total squared error is split next. Segment slopes and
+    residual variances are exposed both chronologically and in return-ordered
+    state space, so the result can seed later HMM initialization work.
+
+    References: §3.1 PLR baseline (engineering approximation)
+    """
+
+    values = _coerce_series(series)
+    if n_segments < 2:
+        raise ValueError(f"n_segments must be at least 2, got {n_segments}.")
+    if min_segment_length < 2:
+        raise ValueError(
+            f"min_segment_length must be at least 2, got {min_segment_length}."
+        )
+    if len(values) < n_segments * min_segment_length:
+        raise ValueError(
+            "series is too short for the requested segmentation; "
+            f"len(series)={len(values)}, n_segments={n_segments}, "
+            f"min_segment_length={min_segment_length}."
+        )
+
+    n_obs = len(values)
+    x = np.arange(n_obs, dtype=float)
+    prefix_x = _prefix_sum(x)
+    prefix_xx = _prefix_sum(x * x)
+    prefix_y = _prefix_sum(values)
+    prefix_yy = _prefix_sum(values * values)
+    prefix_xy = _prefix_sum(x * values)
+
+    @cache
+    def interval_fit(start_idx: int, end_idx: int) -> _IntervalFit:
+        n_interval = end_idx - start_idx
+        sum_x = prefix_x[end_idx] - prefix_x[start_idx]
+        sum_y = prefix_y[end_idx] - prefix_y[start_idx]
+        sum_xx = prefix_xx[end_idx] - prefix_xx[start_idx]
+        sum_yy = prefix_yy[end_idx] - prefix_yy[start_idx]
+        sum_xy = prefix_xy[end_idx] - prefix_xy[start_idx]
+
+        if n_interval == 1:
+            intercept = float(values[start_idx])
+            return _IntervalFit(slope=0.0, intercept=intercept, sse=0.0)
+
+        denominator = n_interval * sum_xx - sum_x * sum_x
+        if np.isclose(denominator, 0.0):
+            slope = 0.0
+            intercept = sum_y / n_interval
+        else:
+            slope = (n_interval * sum_xy - sum_x * sum_y) / denominator
+            intercept = (sum_y - slope * sum_x) / n_interval
+
+        sse = (
+            sum_yy
+            - 2.0 * intercept * sum_y
+            - 2.0 * slope * sum_xy
+            + n_interval * intercept * intercept
+            + 2.0 * intercept * slope * sum_x
+            + slope * slope * sum_xx
+        )
+        return _IntervalFit(
+            slope=float(slope),
+            intercept=float(intercept),
+            sse=float(max(sse, 0.0)),
+        )
+
+    cost = np.full((n_segments + 1, n_obs + 1), np.inf, dtype=float)
+    previous_start = np.full((n_segments + 1, n_obs + 1), -1, dtype=int)
+    cost[0, 0] = 0.0
+
+    for segment_count in range(1, n_segments + 1):
+        min_end = segment_count * min_segment_length
+        max_end = n_obs - (n_segments - segment_count) * min_segment_length
+        for end_idx in range(min_end, max_end + 1):
+            start_min = (segment_count - 1) * min_segment_length
+            start_max = end_idx - min_segment_length
+            best_cost = np.inf
+            best_start = -1
+
+            for start_idx in range(start_min, start_max + 1):
+                previous_cost = cost[segment_count - 1, start_idx]
+                if not np.isfinite(previous_cost):
+                    continue
+                candidate_cost = previous_cost + interval_fit(start_idx, end_idx).sse
+                if candidate_cost < best_cost:
+                    best_cost = candidate_cost
+                    best_start = start_idx
+
+            cost[segment_count, end_idx] = best_cost
+            previous_start[segment_count, end_idx] = best_start
+
+    if not np.isfinite(cost[n_segments, n_obs]):
+        raise ValueError(
+            "Unable to segment the series with the requested configuration; "
+            f"n_segments={n_segments}, min_segment_length={min_segment_length}."
+        )
+
+    segment_ranges: list[tuple[int, int]] = []
+    end_idx = n_obs
+    for segment_count in range(n_segments, 0, -1):
+        start_idx = previous_start[segment_count, end_idx]
+        if start_idx < 0:
+            raise ValueError("Segmentation backtracking failed to recover segment boundaries.")
+        segment_ranges.append((start_idx, end_idx))
+        end_idx = start_idx
+    segment_ranges.reverse()
+
+    breakpoints = tuple(end_idx for _, end_idx in segment_ranges)
+    slopes = np.array(
+        [interval_fit(start_idx, end_idx).slope for start_idx, end_idx in segment_ranges],
+        dtype=float,
+    )
+    order = np.argsort(slopes, kind="mergesort")
+    labels = default_labels(n_segments)
+    state_index_by_segment = {
+        segment_index: state_index for state_index, segment_index in enumerate(order.tolist())
+    }
+
+    segments: list[PLRSegment] = []
+    state_summaries: list[PLRStateSummary] = []
+    fitted_values = np.empty(n_obs, dtype=float)
+    residuals = np.empty(n_obs, dtype=float)
+    segment_assignments = np.empty(n_obs, dtype=int)
+    state_sequence = np.empty(n_obs, dtype=int)
+
+    for segment_index, (start_idx, end_idx) in enumerate(segment_ranges):
+        fit = interval_fit(start_idx, end_idx)
+        state_index = state_index_by_segment[segment_index]
+        x_segment = x[start_idx:end_idx]
+        fitted_segment = fit.slope * x_segment + fit.intercept
+        segment_residuals = values[start_idx:end_idx] - fitted_segment
+        residual_variance = float(np.mean(segment_residuals**2))
+
+        fitted_values[start_idx:end_idx] = fitted_segment
+        residuals[start_idx:end_idx] = segment_residuals
+        segment_assignments[start_idx:end_idx] = segment_index
+        state_sequence[start_idx:end_idx] = state_index
+
+        segments.append(
+            PLRSegment(
+                segment_index=segment_index,
+                state_index=state_index,
+                start_idx=start_idx,
+                end_idx=end_idx,
+                slope=fit.slope,
+                intercept=fit.intercept,
+                residual_variance=residual_variance,
+            )
+        )
+
+    ordered_segments = [segments[segment_index] for segment_index in order.tolist()]
+    state_grid = StateGrid(
+        k=n_segments,
+        means=np.array([segment.slope for segment in ordered_segments], dtype=float),
+        labels=labels,
+    )
+
+    for state_index, segment in enumerate(ordered_segments):
+        state_summaries.append(
+            PLRStateSummary(
+                state_index=state_index,
+                label=labels[state_index],
+                segment_index=segment.segment_index,
+                start_idx=segment.start_idx,
+                end_idx=segment.end_idx,
+                slope=segment.slope,
+                residual_variance=segment.residual_variance,
+            )
+        )
+
+    dw_stat = float(durbin_watson(residuals)) if compute_durbin_watson else None
+
+    return PLRBaselineResult(
+        segments=tuple(segments),
+        state_summaries=tuple(state_summaries),
+        state_grid=state_grid,
+        breakpoints=breakpoints,
+        fitted_values=fitted_values,
+        residuals=residuals,
+        segment_assignments=segment_assignments,
+        state_sequence=state_sequence,
+        durbin_watson=dw_stat,
+    )
+
+
+def _coerce_series(series: pd.Series | np.ndarray) -> np.ndarray:
+    values = np.asarray(series, dtype=float)
+    if values.ndim != 1:
+        raise ValueError(f"series must be one-dimensional, got shape {values.shape}.")
+    if values.size == 0:
+        raise ValueError("series must contain at least one observation.")
+    invalid_positions = np.flatnonzero(~np.isfinite(values))
+    if invalid_positions.size > 0:
+        shown = ", ".join(str(position) for position in invalid_positions[:5])
+        if invalid_positions.size > 5:
+            shown = f"{shown}, ..."
+        raise ValueError(
+            "series must contain only finite values; "
+            f"found {invalid_positions.size} invalid value(s) at position(s): {shown}."
+        )
+    return values
+
+
+def _prefix_sum(values: np.ndarray) -> np.ndarray:
+    return np.concatenate((np.array([0.0]), np.cumsum(values, dtype=float)))

--- a/src/hft_hmm/models/plr_baseline.py
+++ b/src/hft_hmm/models/plr_baseline.py
@@ -167,11 +167,14 @@ def fit_piecewise_linear_regression(
 ) -> PLRBaselineResult:
     """Fit a deterministic piecewise linear regression baseline to ``series``.
 
-    The series is segmented chronologically using a greedy top-down split rule:
-    at each step, the current segment whose best admissible split yields the
-    largest reduction in total squared error is split next. Segment slopes and
-    residual variances are exposed both chronologically and in return-ordered
-    state space, so the result can seed later HMM initialization work.
+    The series is segmented chronologically via dynamic programming that
+    minimizes total squared error under the ``min_segment_length`` constraint.
+    The 2D DP tables ``cost`` and ``previous_start`` store optimal partial
+    solutions and allow exact backtracking of globally optimal segment
+    boundaries. Segment slopes and residual variances are exposed both
+    chronologically and in return-ordered state space, so the result can seed
+    later HMM initialization work. The DP routine runs in roughly
+    :math:`O(k * n^2)` time for ``k = n_segments`` and ``n = len(series)``.
 
     References: §3.1 PLR baseline (engineering approximation)
     """
@@ -180,9 +183,7 @@ def fit_piecewise_linear_regression(
     if n_segments < 2:
         raise ValueError(f"n_segments must be at least 2, got {n_segments}.")
     if min_segment_length < 2:
-        raise ValueError(
-            f"min_segment_length must be at least 2, got {min_segment_length}."
-        )
+        raise ValueError(f"min_segment_length must be at least 2, got {min_segment_length}.")
     if len(values) < n_segments * min_segment_length:
         raise ValueError(
             "series is too short for the requested segmentation; "
@@ -274,7 +275,7 @@ def fit_piecewise_linear_regression(
         end_idx = start_idx
     segment_ranges.reverse()
 
-    breakpoints = tuple(end_idx for _, end_idx in segment_ranges)
+    breakpoints = tuple(bp_end for _, bp_end in segment_ranges)
     slopes = np.array(
         [interval_fit(start_idx, end_idx).slope for start_idx, end_idx in segment_ranges],
         dtype=float,
@@ -353,6 +354,22 @@ def fit_piecewise_linear_regression(
 
 
 def _coerce_series(series: pd.Series | np.ndarray) -> np.ndarray:
+    """Coerce input values to a finite one-dimensional float array.
+
+    If ``series`` is a pandas ``Series`` with a ``DatetimeIndex``, the index
+    must be monotonic increasing to preserve chronological order for
+    segmentation.
+    """
+    if (
+        isinstance(series, pd.Series)
+        and isinstance(series.index, pd.DatetimeIndex)
+        and not series.index.is_monotonic_increasing
+    ):
+        raise ValueError(
+            "series DatetimeIndex must be monotonic increasing; "
+            "sort with series.sort_index() before calling fit_piecewise_linear_regression."
+        )
+
     values = np.asarray(series, dtype=float)
     if values.ndim != 1:
         raise ValueError(f"series must be one-dimensional, got shape {values.shape}.")

--- a/tests/test_plr_baseline.py
+++ b/tests/test_plr_baseline.py
@@ -70,6 +70,8 @@ def test_fit_piecewise_linear_regression_is_deterministic_on_noisy_input() -> No
     assert first.breakpoints == second.breakpoints
     assert first.fitted_values.tolist() == pytest.approx(second.fitted_values.tolist())
     assert first.state_means.tolist() == pytest.approx(second.state_means.tolist())
+    assert first.state_sequence.tolist() == second.state_sequence.tolist()
+    assert first.segment_assignments.tolist() == second.segment_assignments.tolist()
 
 
 def test_fit_piecewise_linear_regression_rejects_invalid_configuration() -> None:

--- a/tests/test_plr_baseline.py
+++ b/tests/test_plr_baseline.py
@@ -1,0 +1,90 @@
+"""Tests for the piecewise linear regression baseline."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from hft_hmm.core import ENGINEERING_APPROXIMATION, module_category
+from hft_hmm.models import fit_piecewise_linear_regression, plr_baseline
+
+
+def _piecewise_trend(slopes: list[float], segment_length: int) -> pd.Series:
+    values: list[float] = []
+    current = 10.0
+    for slope in slopes:
+        for _ in range(segment_length):
+            values.append(current)
+            current += slope
+    return pd.Series(values, dtype=float)
+
+
+def test_plr_baseline_declares_engineering_category() -> None:
+    assert module_category(plr_baseline) == ENGINEERING_APPROXIMATION
+
+
+def test_fit_piecewise_linear_regression_segments_clean_synthetic_trend() -> None:
+    series = _piecewise_trend([-0.02, 0.0, 0.03], segment_length=20)
+
+    result = fit_piecewise_linear_regression(
+        series,
+        n_segments=3,
+        compute_durbin_watson=True,
+    )
+
+    assert result.breakpoints == (20, 40, 60)
+    assert [segment.start_idx for segment in result.segments] == [0, 20, 40]
+    assert [segment.end_idx for segment in result.segments] == [20, 40, 60]
+    assert [segment.slope for segment in result.segments] == pytest.approx([-0.02, 0.0, 0.03])
+    assert result.state_grid.labels == ("down", "flat", "up")
+    assert result.state_means.tolist() == pytest.approx([-0.02, 0.0, 0.03])
+    assert result.state_variances.tolist() == pytest.approx([0.0, 0.0, 0.0])
+    assert result.state_sequence[:20].tolist() == [0] * 20
+    assert result.state_sequence[20:40].tolist() == [1] * 20
+    assert result.state_sequence[40:].tolist() == [2] * 20
+    assert result.durbin_watson is not None
+
+
+def test_fit_piecewise_linear_regression_orders_states_by_slope() -> None:
+    series = _piecewise_trend([0.02, -0.01, 0.03], segment_length=12)
+
+    result = fit_piecewise_linear_regression(series, n_segments=3)
+
+    assert [segment.slope for segment in result.segments] == pytest.approx([0.02, -0.01, 0.03])
+    assert result.state_means.tolist() == pytest.approx([-0.01, 0.02, 0.03])
+    assert [summary.segment_index for summary in result.state_summaries] == [1, 0, 2]
+    for segment in result.segments:
+        assigned_states = result.state_sequence[segment.start_idx : segment.end_idx]
+        assert assigned_states.tolist() == [segment.state_index] * segment.n_obs
+
+
+def test_fit_piecewise_linear_regression_is_deterministic_on_noisy_input() -> None:
+    x = np.arange(45, dtype=float)
+    base = _piecewise_trend([-0.01, 0.015, 0.005], segment_length=15).to_numpy()
+    noisy_series = pd.Series(base + 0.001 * np.sin(x), dtype=float)
+
+    first = fit_piecewise_linear_regression(noisy_series, n_segments=3)
+    second = fit_piecewise_linear_regression(noisy_series, n_segments=3)
+
+    assert first.breakpoints == second.breakpoints
+    assert first.fitted_values.tolist() == pytest.approx(second.fitted_values.tolist())
+    assert first.state_means.tolist() == pytest.approx(second.state_means.tolist())
+
+
+def test_fit_piecewise_linear_regression_rejects_invalid_configuration() -> None:
+    series = pd.Series(np.linspace(1.0, 2.0, num=5), dtype=float)
+
+    with pytest.raises(ValueError, match="at least 2"):
+        fit_piecewise_linear_regression(series, n_segments=1)
+    with pytest.raises(ValueError, match="min_segment_length must be at least 2"):
+        fit_piecewise_linear_regression(series, n_segments=2, min_segment_length=1)
+    with pytest.raises(ValueError, match="too short for the requested segmentation"):
+        fit_piecewise_linear_regression(series, n_segments=3, min_segment_length=2)
+
+
+def test_fit_piecewise_linear_regression_rejects_non_finite_values() -> None:
+    series = pd.Series([1.0, np.nan, 2.0], dtype=float)
+
+    with pytest.raises(ValueError, match="only finite values"):
+        fit_piecewise_linear_regression(series, n_segments=2)


### PR DESCRIPTION
## Summary
- add a deterministic piecewise linear regression baseline for segmented trend initialization
- expose chronological segments, ordered state summaries, a state grid, and optional Durbin-Watson diagnostics
- add synthetic and edge-case tests covering segmentation, state ordering, determinism, and invalid input

## Validation
- pytest
- ruff check .
- mypy src

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added piecewise linear regression baseline for time series analysis, enabling segmentation with configurable segment count and minimum length constraints
  * Provides segment details, state summaries, state ordering, and optional statistical diagnostics
  * Fully exported from main module for direct use

* **Tests**
  * Added comprehensive test suite covering model fitting, input validation, and deterministic behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->