### PR TITLE
feat(06): Gaussian HMM wrapper with PLR init

### DIFF
--- a/src/hft_hmm/__init__.py
+++ b/src/hft_hmm/__init__.py
@@ -22,6 +22,8 @@ from hft_hmm.data import (
     validate_market_data,
 )
 from hft_hmm.models import (
+    GaussianHMMResult,
+    GaussianHMMWrapper,
     PLRBaselineResult,
     PLRSegment,
     PLRStateSummary,
@@ -36,6 +38,8 @@ __all__ = [
     "EVALUATION_LAYER",
     "PAPER_FAITHFUL",
     "PROJECT_NAME",
+    "GaussianHMMResult",
+    "GaussianHMMWrapper",
     "MarketDataSpec",
     "MarketDataValidationError",
     "PaperReference",

--- a/src/hft_hmm/models/__init__.py
+++ b/src/hft_hmm/models/__init__.py
@@ -1,5 +1,6 @@
 """Model-building primitives used by the HMM trading project."""
 
+from hft_hmm.models.gaussian_hmm import GaussianHMMResult, GaussianHMMWrapper
 from hft_hmm.models.plr_baseline import (
     PLRBaselineResult,
     PLRSegment,
@@ -7,12 +8,15 @@ from hft_hmm.models.plr_baseline import (
     fit_piecewise_linear_regression,
 )
 
-from . import plr_baseline
+from . import gaussian_hmm, plr_baseline
 
 __all__ = [
+    "GaussianHMMResult",
+    "GaussianHMMWrapper",
     "PLRBaselineResult",
     "PLRSegment",
     "PLRStateSummary",
     "fit_piecewise_linear_regression",
+    "gaussian_hmm",
     "plr_baseline",
 ]

--- a/src/hft_hmm/models/gaussian_hmm.py
+++ b/src/hft_hmm/models/gaussian_hmm.py
@@ -76,12 +76,33 @@ class GaussianHMMResult:
             raise ValueError(f"transition_matrix must have shape ({k}, {k}), got {transmat.shape}.")
         if startprob.shape != (k,):
             raise ValueError(f"initial_distribution must have shape ({k},), got {startprob.shape}.")
-        if np.any(variances < 0.0):
-            raise ValueError("variances must be non-negative.")
-        if not np.all(np.isclose(transmat.sum(axis=1), 1.0)):
+        state_grid_means = np.asarray(self.state_grid.means, dtype=float)
+        if state_grid_means.shape != (k,):
+            raise ValueError(
+                f"state_grid.means must have shape ({k},), got {state_grid_means.shape}."
+            )
+        if not np.all(np.isfinite(means)):
+            raise ValueError("means must contain only finite values.")
+        if not np.all(np.isfinite(variances)):
+            raise ValueError("variances must contain only finite values.")
+        if not np.all(variances > 0.0):
+            raise ValueError("variances must be strictly positive.")
+        if not np.all(np.isfinite(transmat)):
+            raise ValueError("transition_matrix must contain only finite values.")
+        if not np.all(transmat >= 0.0):
+            raise ValueError("transition_matrix entries must be non-negative.")
+        if not np.allclose(transmat.sum(axis=1), 1.0):
             raise ValueError("transition_matrix rows must sum to 1.")
+        if not np.all(np.isfinite(startprob)):
+            raise ValueError("initial_distribution must contain only finite values.")
+        if not np.all(startprob >= 0.0):
+            raise ValueError("initial_distribution entries must be non-negative.")
         if not np.isclose(startprob.sum(), 1.0):
             raise ValueError("initial_distribution must sum to 1.")
+        if not np.all(np.isfinite(state_grid_means)):
+            raise ValueError("state_grid.means must contain only finite values.")
+        if not np.allclose(means, state_grid_means):
+            raise ValueError("means must match state_grid.means.")
         if self.n_observations < 1:
             raise ValueError("n_observations must be positive.")
 

--- a/src/hft_hmm/models/gaussian_hmm.py
+++ b/src/hft_hmm/models/gaussian_hmm.py
@@ -1,0 +1,263 @@
+"""Gaussian HMM wrapper around ``hmmlearn`` for one-dimensional return series.
+
+This module is an engineering wrapper: the EM/Baum-Welch fit, Viterbi decoding,
+and forward-backward posterior computation are delegated to
+``hmmlearn.hmm.GaussianHMM``. The wrapper adds:
+
+- a frozen result dataclass exposing the learned parameters as numpy arrays,
+- canonical state ordering (ascending mean return) so downstream filtering and
+  signal code can assume a stable ``StateGrid`` convention,
+- deterministic ``random_state`` plumbing,
+- an ``init_from_plr`` path that seeds ``startprob_``, ``transmat_``,
+  ``means_``, and ``covars_`` from an Issue 05 PLR baseline result, matching
+  the paper's recommended initialization strategy.
+
+See ``GAUSSIAN_HMM_REFERENCE`` for the paper pointer used in docstrings and
+review notes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+import numpy as np
+import pandas as pd
+from hmmlearn.hmm import GaussianHMM
+
+from hft_hmm.core import (
+    ENGINEERING_APPROXIMATION,
+    PaperReference,
+    StateGrid,
+    default_labels,
+    reference,
+)
+from hft_hmm.models.plr_baseline import PLRBaselineResult
+
+__category__: Final[str] = ENGINEERING_APPROXIMATION
+GAUSSIAN_HMM_REFERENCE: Final[PaperReference] = reference("§3", "Gaussian HMM baseline")
+
+_MIN_VARIANCE: Final[float] = 1e-8
+_TRANSMAT_SMOOTHING: Final[float] = 1.0
+
+
+@dataclass(frozen=True)
+class GaussianHMMResult:
+    """Immutable snapshot of a fitted Gaussian HMM.
+
+    Arrays are ordered by ascending mean return (the ``StateGrid`` convention),
+    so ``means[i]``, ``variances[i]``, ``transition_matrix[i, :]``, and
+    ``initial_distribution[i]`` all refer to the same state ``i``.
+    """
+
+    state_grid: StateGrid
+    means: np.ndarray
+    variances: np.ndarray
+    transition_matrix: np.ndarray
+    initial_distribution: np.ndarray
+    log_likelihood: float
+    n_observations: int
+    converged: bool
+    n_iter: int
+    random_state: int | None
+
+    def __post_init__(self) -> None:
+        k = self.state_grid.k
+        means = np.asarray(self.means, dtype=float).copy()
+        variances = np.asarray(self.variances, dtype=float).copy()
+        transmat = np.asarray(self.transition_matrix, dtype=float).copy()
+        startprob = np.asarray(self.initial_distribution, dtype=float).copy()
+
+        if means.shape != (k,):
+            raise ValueError(f"means must have shape ({k},), got {means.shape}.")
+        if variances.shape != (k,):
+            raise ValueError(f"variances must have shape ({k},), got {variances.shape}.")
+        if transmat.shape != (k, k):
+            raise ValueError(f"transition_matrix must have shape ({k}, {k}), got {transmat.shape}.")
+        if startprob.shape != (k,):
+            raise ValueError(f"initial_distribution must have shape ({k},), got {startprob.shape}.")
+        if np.any(variances < 0.0):
+            raise ValueError("variances must be non-negative.")
+        if not np.all(np.isclose(transmat.sum(axis=1), 1.0)):
+            raise ValueError("transition_matrix rows must sum to 1.")
+        if not np.isclose(startprob.sum(), 1.0):
+            raise ValueError("initial_distribution must sum to 1.")
+        if self.n_observations < 1:
+            raise ValueError("n_observations must be positive.")
+
+        for array in (means, variances, transmat, startprob):
+            array.setflags(write=False)
+
+        object.__setattr__(self, "means", means)
+        object.__setattr__(self, "variances", variances)
+        object.__setattr__(self, "transition_matrix", transmat)
+        object.__setattr__(self, "initial_distribution", startprob)
+
+
+class GaussianHMMWrapper:
+    """Reviewable wrapper around ``hmmlearn.hmm.GaussianHMM`` for 1-D returns.
+
+    The wrapper fits a diagonal-covariance Gaussian HMM on a univariate series,
+    re-orders the learned states by ascending mean return, and exposes the
+    result as a ``GaussianHMMResult``. ``predict`` and ``predict_proba`` return
+    state indices consistent with that canonical ordering.
+
+    References: §3 Gaussian HMM baseline (engineering wrapper around hmmlearn)
+    """
+
+    def __init__(
+        self,
+        n_states: int,
+        *,
+        random_state: int | None = None,
+        n_iter: int = 100,
+        tol: float = 1e-4,
+    ) -> None:
+        if n_states < 2:
+            raise ValueError(f"n_states must be at least 2, got {n_states}.")
+        if n_iter < 1:
+            raise ValueError(f"n_iter must be positive, got {n_iter}.")
+        if tol <= 0.0:
+            raise ValueError(f"tol must be strictly positive, got {tol}.")
+
+        self.n_states = n_states
+        self.random_state = random_state
+        self.n_iter = n_iter
+        self.tol = tol
+        self._model: GaussianHMM | None = None
+        self._permutation: np.ndarray | None = None
+
+    def fit(
+        self,
+        returns: pd.Series | np.ndarray,
+        *,
+        init_from_plr: PLRBaselineResult | None = None,
+    ) -> GaussianHMMResult:
+        """Fit the Gaussian HMM and return a canonical result snapshot.
+
+        Passing ``init_from_plr`` seeds EM from the supplied PLR baseline.
+        Without it, ``hmmlearn`` draws its own initialization using
+        ``random_state``.
+        """
+        observations = _coerce_returns(returns)
+        reshaped = observations.reshape(-1, 1)
+
+        if init_from_plr is not None and init_from_plr.state_grid.k != self.n_states:
+            raise ValueError(
+                "init_from_plr.state_grid.k does not match wrapper n_states; "
+                f"got {init_from_plr.state_grid.k} vs {self.n_states}."
+            )
+
+        init_params = "" if init_from_plr is not None else "stmc"
+        model = GaussianHMM(
+            n_components=self.n_states,
+            covariance_type="diag",
+            n_iter=self.n_iter,
+            tol=self.tol,
+            random_state=self.random_state,
+            init_params=init_params,
+            params="stmc",
+        )
+
+        if init_from_plr is not None:
+            _seed_from_plr(model, init_from_plr)
+
+        model.fit(reshaped)
+        log_likelihood = float(model.score(reshaped))
+
+        means_raw = model.means_.reshape(-1)
+        variances_raw = model.covars_.reshape(-1)
+        permutation = np.argsort(means_raw, kind="mergesort")
+
+        means_sorted = means_raw[permutation]
+        variances_sorted = variances_raw[permutation]
+        transmat_sorted = model.transmat_[permutation][:, permutation]
+        startprob_sorted = model.startprob_[permutation]
+
+        state_grid = StateGrid(
+            k=self.n_states,
+            means=means_sorted,
+            labels=default_labels(self.n_states),
+        )
+
+        self._model = model
+        self._permutation = permutation
+
+        return GaussianHMMResult(
+            state_grid=state_grid,
+            means=means_sorted,
+            variances=variances_sorted,
+            transition_matrix=transmat_sorted,
+            initial_distribution=startprob_sorted,
+            log_likelihood=log_likelihood,
+            n_observations=int(observations.shape[0]),
+            converged=bool(model.monitor_.converged),
+            n_iter=int(model.monitor_.iter),
+            random_state=self.random_state,
+        )
+
+    def predict(self, returns: pd.Series | np.ndarray) -> np.ndarray:
+        """Return the Viterbi-most-likely state sequence in canonical ordering."""
+        model, permutation = self._require_fitted()
+        reshaped = _coerce_returns(returns).reshape(-1, 1)
+        raw_states = model.predict(reshaped)
+        return _apply_permutation(raw_states, permutation)
+
+    def predict_proba(self, returns: pd.Series | np.ndarray) -> np.ndarray:
+        """Return forward-backward posteriors ordered by canonical state index."""
+        model, permutation = self._require_fitted()
+        reshaped = _coerce_returns(returns).reshape(-1, 1)
+        raw_posteriors = np.asarray(model.predict_proba(reshaped), dtype=float)
+        return raw_posteriors[:, permutation]
+
+    def _require_fitted(self) -> tuple[GaussianHMM, np.ndarray]:
+        if self._model is None or self._permutation is None:
+            raise RuntimeError("Call fit() before predict() or predict_proba().")
+        return self._model, self._permutation
+
+
+def _coerce_returns(returns: pd.Series | np.ndarray) -> np.ndarray:
+    """Validate and return a finite 1-D float array of return observations."""
+    values = np.asarray(returns, dtype=float)
+    if values.ndim != 1:
+        raise ValueError(f"returns must be one-dimensional, got shape {values.shape}.")
+    if values.size == 0:
+        raise ValueError("returns must contain at least one observation.")
+    if not np.all(np.isfinite(values)):
+        raise ValueError("returns must contain only finite values; drop NaN/inf first.")
+    return values
+
+
+def _apply_permutation(raw_states: np.ndarray, permutation: np.ndarray) -> np.ndarray:
+    """Map raw hmmlearn state indices into the ascending-mean canonical order."""
+    inverse = np.empty_like(permutation)
+    inverse[permutation] = np.arange(permutation.size)
+    return np.asarray(inverse[raw_states], dtype=permutation.dtype)
+
+
+def _seed_from_plr(model: GaussianHMM, plr: PLRBaselineResult) -> None:
+    """Set model parameters from a PLR baseline result before fitting.
+
+    Transition probabilities are smoothed with an additive Laplace prior so
+    states that the PLR sequence never left keep non-zero off-diagonal mass,
+    which prevents EM from locking into degenerate solutions.
+    """
+    k = plr.state_grid.k
+    means = plr.state_grid.means.reshape(k, 1).astype(float, copy=True)
+    variances = np.maximum(plr.state_variances.astype(float, copy=True), _MIN_VARIANCE)
+    covars = variances.reshape(k, 1)
+
+    state_sequence = np.asarray(plr.state_sequence, dtype=int)
+    transmat = np.full((k, k), _TRANSMAT_SMOOTHING, dtype=float)
+    for previous, current in zip(state_sequence[:-1], state_sequence[1:], strict=True):
+        transmat[previous, current] += 1.0
+    transmat /= transmat.sum(axis=1, keepdims=True)
+
+    startprob = np.full(k, _TRANSMAT_SMOOTHING, dtype=float)
+    startprob[int(state_sequence[0])] += 1.0
+    startprob /= startprob.sum()
+
+    model.startprob_ = startprob
+    model.transmat_ = transmat
+    model.means_ = means
+    model.covars_ = covars

--- a/tests/test_gaussian_hmm_wrapper.py
+++ b/tests/test_gaussian_hmm_wrapper.py
@@ -1,0 +1,190 @@
+"""Tests for the GaussianHMMWrapper and init_from_plr seeding path."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from hft_hmm.models.gaussian_hmm import GaussianHMMResult, GaussianHMMWrapper
+from hft_hmm.models.plr_baseline import fit_piecewise_linear_regression
+
+
+def _sample_two_regime_returns(
+    *,
+    low_mean: float = -1.0,
+    high_mean: float = 1.0,
+    sigma: float = 0.3,
+    per_regime: int = 400,
+    n_blocks: int = 4,
+    seed: int = 0,
+) -> np.ndarray:
+    """Synthetic two-regime returns with means separated at several sigma.
+
+    The absolute magnitudes are intentionally large (unit-scale) so that
+    hmmlearn's default KMeans-based initialization finds the two modes; the
+    assertions only care about regime recovery, not realistic return scales.
+    """
+    rng = np.random.default_rng(seed)
+    chunks = []
+    for block in range(n_blocks):
+        mean = low_mean if block % 2 == 0 else high_mean
+        chunks.append(rng.normal(loc=mean, scale=sigma, size=per_regime))
+    return np.concatenate(chunks)
+
+
+def _sample_two_regime_prices(
+    *,
+    low_slope: float = -0.5,
+    high_slope: float = 0.5,
+    noise: float = 0.05,
+    per_regime: int = 120,
+    n_blocks: int = 4,
+    seed: int = 0,
+) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    prices = []
+    current = 0.0
+    for block in range(n_blocks):
+        slope = low_slope if block % 2 == 0 else high_slope
+        x_local = np.arange(per_regime, dtype=float)
+        noise_local = rng.normal(scale=noise, size=per_regime)
+        block_values = current + slope * x_local + noise_local
+        prices.append(block_values)
+        current = float(block_values[-1])
+    return np.concatenate(prices)
+
+
+def test_wrapper_recovers_two_regime_means():
+    returns = _sample_two_regime_returns(seed=1)
+    wrapper = GaussianHMMWrapper(n_states=2, random_state=42, n_iter=200)
+    result = wrapper.fit(returns)
+    low, high = result.means
+    assert low < 0 < high
+    assert abs(low - -1.0) < 0.1
+    assert abs(high - 1.0) < 0.1
+
+
+def test_result_arrays_have_correct_shapes_and_normalization():
+    returns = _sample_two_regime_returns(seed=2)
+    wrapper = GaussianHMMWrapper(n_states=2, random_state=42)
+    result = wrapper.fit(returns)
+
+    assert isinstance(result, GaussianHMMResult)
+    assert result.means.shape == (2,)
+    assert result.variances.shape == (2,)
+    assert result.transition_matrix.shape == (2, 2)
+    assert result.initial_distribution.shape == (2,)
+    assert np.allclose(result.transition_matrix.sum(axis=1), 1.0)
+    assert np.isclose(result.initial_distribution.sum(), 1.0)
+    assert np.all(result.variances > 0.0)
+
+
+def test_result_state_grid_means_ascending():
+    returns = _sample_two_regime_returns(seed=3)
+    wrapper = GaussianHMMWrapper(n_states=2, random_state=42)
+    result = wrapper.fit(returns)
+    assert np.all(np.diff(result.state_grid.means) > 0)
+    assert np.array_equal(result.state_grid.means, result.means)
+
+
+def test_predict_proba_rows_sum_to_one():
+    returns = _sample_two_regime_returns(seed=4)
+    wrapper = GaussianHMMWrapper(n_states=2, random_state=42)
+    wrapper.fit(returns)
+    posteriors = wrapper.predict_proba(returns)
+    assert posteriors.shape == (returns.shape[0], 2)
+    assert np.allclose(posteriors.sum(axis=1), 1.0)
+
+
+def test_predict_returns_valid_state_indices():
+    returns = _sample_two_regime_returns(seed=5)
+    wrapper = GaussianHMMWrapper(n_states=2, random_state=42)
+    wrapper.fit(returns)
+    states = wrapper.predict(returns)
+    assert states.shape == (returns.shape[0],)
+    assert states.min() >= 0
+    assert states.max() < 2
+
+
+def test_fit_is_deterministic_under_fixed_random_state():
+    returns = _sample_two_regime_returns(seed=6)
+    first = GaussianHMMWrapper(n_states=2, random_state=7).fit(returns)
+    second = GaussianHMMWrapper(n_states=2, random_state=7).fit(returns)
+    np.testing.assert_allclose(first.means, second.means)
+    np.testing.assert_allclose(first.variances, second.variances)
+    np.testing.assert_allclose(first.transition_matrix, second.transition_matrix)
+    np.testing.assert_allclose(first.initial_distribution, second.initial_distribution)
+
+
+def test_init_from_plr_produces_reproducible_fit():
+    prices = _sample_two_regime_prices(seed=11)
+    plr = fit_piecewise_linear_regression(prices, n_segments=2)
+    returns = np.diff(prices)
+    first = GaussianHMMWrapper(n_states=2).fit(returns, init_from_plr=plr)
+    second = GaussianHMMWrapper(n_states=2).fit(returns, init_from_plr=plr)
+    np.testing.assert_allclose(first.means, second.means)
+    np.testing.assert_allclose(first.transition_matrix, second.transition_matrix)
+    np.testing.assert_allclose(first.initial_distribution, second.initial_distribution)
+
+
+def test_init_from_plr_rejects_mismatched_k():
+    prices = _sample_two_regime_prices(seed=12)
+    plr = fit_piecewise_linear_regression(prices, n_segments=2)
+    wrapper = GaussianHMMWrapper(n_states=3)
+    with pytest.raises(ValueError, match="does not match wrapper n_states"):
+        wrapper.fit(np.diff(prices), init_from_plr=plr)
+
+
+def test_predict_before_fit_raises():
+    wrapper = GaussianHMMWrapper(n_states=2)
+    with pytest.raises(RuntimeError, match="Call fit"):
+        wrapper.predict(np.zeros(5))
+
+
+def test_predict_proba_before_fit_raises():
+    wrapper = GaussianHMMWrapper(n_states=2)
+    with pytest.raises(RuntimeError, match="Call fit"):
+        wrapper.predict_proba(np.zeros(5))
+
+
+def test_fit_rejects_nan_input():
+    wrapper = GaussianHMMWrapper(n_states=2, random_state=0)
+    returns = np.array([0.0, 0.1, np.nan, 0.2])
+    with pytest.raises(ValueError, match="finite"):
+        wrapper.fit(returns)
+
+
+def test_fit_rejects_multidim_input():
+    wrapper = GaussianHMMWrapper(n_states=2, random_state=0)
+    returns = np.zeros((5, 2))
+    with pytest.raises(ValueError, match="one-dimensional"):
+        wrapper.fit(returns)
+
+
+def test_fit_rejects_empty_input():
+    wrapper = GaussianHMMWrapper(n_states=2, random_state=0)
+    with pytest.raises(ValueError, match="at least one observation"):
+        wrapper.fit(np.array([], dtype=float))
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [{"n_states": 1}, {"n_states": 2, "n_iter": 0}, {"n_states": 2, "tol": 0.0}],
+)
+def test_constructor_validates_arguments(kwargs):
+    with pytest.raises(ValueError):
+        GaussianHMMWrapper(**kwargs)
+
+
+def test_result_is_frozen_and_arrays_read_only():
+    returns = _sample_two_regime_returns(seed=9)
+    wrapper = GaussianHMMWrapper(n_states=2, random_state=42)
+    result = wrapper.fit(returns)
+
+    with pytest.raises(AttributeError):
+        result.log_likelihood = 0.0  # type: ignore[misc]
+
+    with pytest.raises(ValueError):
+        result.means[0] = 0.0
+    with pytest.raises(ValueError):
+        result.transition_matrix[0, 0] = 0.0

--- a/tests/test_gaussian_hmm_wrapper.py
+++ b/tests/test_gaussian_hmm_wrapper.py
@@ -123,6 +123,7 @@ def test_init_from_plr_produces_reproducible_fit():
     first = GaussianHMMWrapper(n_states=2).fit(returns, init_from_plr=plr)
     second = GaussianHMMWrapper(n_states=2).fit(returns, init_from_plr=plr)
     np.testing.assert_allclose(first.means, second.means)
+    np.testing.assert_allclose(first.variances, second.variances)
     np.testing.assert_allclose(first.transition_matrix, second.transition_matrix)
     np.testing.assert_allclose(first.initial_distribution, second.initial_distribution)
 


### PR DESCRIPTION
## Summary
- Add `models/gaussian_hmm.py` wrapping `hmmlearn.hmm.GaussianHMM` for 1-D return series.
- Expose `fit`, `predict`, `predict_proba`, and a frozen `GaussianHMMResult` carrying canonically-ordered `means`, `variances`, `transition_matrix`, `initial_distribution`, `log_likelihood`, `n_iter`, `converged`, and the underlying `StateGrid`.
- Support `init_from_plr` to seed EM from Issue 05's PLR baseline; Laplace-smooths the seeded transition matrix so EM does not lock onto absorbing states.

Closes Issue 06 (Gate C — baseline Gaussian HMM wrapper).

## Test plan
- [x] `.venv/bin/python -m pytest` — 104 tests, 92% coverage
- [x] `.venv/bin/python -m ruff check .` — clean
- [x] `.venv/bin/python -m black --check .` — clean
- [x] `.venv/bin/python -m mypy src` — clean
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Gaussian Hidden Markov Model implementation for modeling return series behavior.
  * New public classes available for fitting HMM models, making predictions, and obtaining probability estimates.
  * Support for initializing HMM parameters from piecewise linear regression results.
  * Comprehensive test coverage for model fitting, validation, and prediction functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->