### PR TITLE
feat(08): log-space forward inference for Gaussian HMM

### DIFF
--- a/src/hft_hmm/__init__.py
+++ b/src/hft_hmm/__init__.py
@@ -21,6 +21,7 @@ from hft_hmm.data import (
     load_yfinance_market_data,
     validate_market_data,
 )
+from hft_hmm.inference import ForwardFilterResult, forward_filter
 from hft_hmm.models import (
     GaussianHMMResult,
     GaussianHMMWrapper,
@@ -47,6 +48,7 @@ __all__ = [
     "EVALUATION_LAYER",
     "PAPER_FAITHFUL",
     "PROJECT_NAME",
+    "ForwardFilterResult",
     "GaussianHMMResult",
     "GaussianHMMWrapper",
     "MarketDataSpec",
@@ -67,6 +69,7 @@ __all__ = [
     "count_gaussian_hmm_parameters",
     "default_labels",
     "fit_piecewise_linear_regression",
+    "forward_filter",
     "get_project_info",
     "linear_grid",
     "load_csv_market_data",

--- a/src/hft_hmm/__init__.py
+++ b/src/hft_hmm/__init__.py
@@ -21,7 +21,7 @@ from hft_hmm.data import (
     load_yfinance_market_data,
     validate_market_data,
 )
-from hft_hmm.inference import ForwardFilterResult, forward_filter
+from hft_hmm.inference import ForwardFilterResult, filter_from_result, forward_filter
 from hft_hmm.models import (
     GaussianHMMResult,
     GaussianHMMWrapper,
@@ -69,6 +69,7 @@ __all__ = [
     "count_gaussian_hmm_parameters",
     "default_labels",
     "fit_piecewise_linear_regression",
+    "filter_from_result",
     "forward_filter",
     "get_project_info",
     "linear_grid",

--- a/src/hft_hmm/inference/__init__.py
+++ b/src/hft_hmm/inference/__init__.py
@@ -1,0 +1,8 @@
+"""Forward-inference utilities for fitted HMM models."""
+
+from hft_hmm.inference.forward_filter import ForwardFilterResult, forward_filter
+
+__all__ = [
+    "ForwardFilterResult",
+    "forward_filter",
+]

--- a/src/hft_hmm/inference/__init__.py
+++ b/src/hft_hmm/inference/__init__.py
@@ -1,8 +1,13 @@
 """Forward-inference utilities for fitted HMM models."""
 
-from hft_hmm.inference.forward_filter import ForwardFilterResult, forward_filter
+from hft_hmm.inference.forward_filter import (
+    ForwardFilterResult,
+    filter_from_result,
+    forward_filter,
+)
 
 __all__ = [
     "ForwardFilterResult",
+    "filter_from_result",
     "forward_filter",
 ]

--- a/src/hft_hmm/inference/forward_filter.py
+++ b/src/hft_hmm/inference/forward_filter.py
@@ -1,0 +1,174 @@
+"""Log-space forward filtering for one-dimensional Gaussian HMM return series.
+
+The forward recursion here is the core filtering step behind the paper's
+expected-return prediction logic: it updates the filtered state probabilities
+``p(m_t | Δy_{1:t})`` and then projects them one step ahead through the
+transition matrix to obtain ``E[Δy_{t+1} | Δy_{1:t}]``.
+
+References: §6 forward filtering and prediction
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+import numpy as np
+import pandas as pd
+from scipy.special import logsumexp
+
+from hft_hmm.core import PAPER_FAITHFUL, StateGrid
+from hft_hmm.models.gaussian_hmm import GaussianHMMResult
+
+__category__: Final[str] = PAPER_FAITHFUL
+
+
+@dataclass(frozen=True)
+class ForwardFilterResult:
+    """Immutable output of the Gaussian-HMM forward filter.
+
+    ``filtering_probabilities[t, i]`` is the normalized filtering probability
+    ``p(m_t = i | Δy_{1:t})``. ``predicted_next_state_probabilities[t, i]`` is
+    ``p(m_{t+1} = i | Δy_{1:t})`` obtained by pushing the filtered
+    distribution one step ahead through the transition matrix. The expected
+    next return is the dot product of the predicted next-state probabilities
+    with the state-mean vector.
+    """
+
+    state_grid: StateGrid
+    filtering_probabilities: np.ndarray
+    predicted_next_state_probabilities: np.ndarray
+    expected_next_returns: np.ndarray
+    log_likelihood: float
+
+    def __post_init__(self) -> None:
+        k = self.state_grid.k
+        filtering = np.asarray(self.filtering_probabilities, dtype=float).copy()
+        predicted = np.asarray(self.predicted_next_state_probabilities, dtype=float).copy()
+        expected = np.asarray(self.expected_next_returns, dtype=float).copy()
+
+        if filtering.ndim != 2:
+            raise ValueError("filtering_probabilities must be a 2-D array.")
+        if filtering.shape[1] != k:
+            raise ValueError(
+                f"filtering_probabilities must have shape (n_obs, {k}), got {filtering.shape}."
+            )
+        if predicted.shape != filtering.shape:
+            raise ValueError(
+                "predicted_next_state_probabilities must have the same shape as "
+                "filtering_probabilities."
+            )
+        if expected.shape != (filtering.shape[0],):
+            raise ValueError(
+                "expected_next_returns must have shape (n_obs,), got "
+                f"{expected.shape} for n_obs={filtering.shape[0]}."
+            )
+        if filtering.shape[0] < 1:
+            raise ValueError("forward filter results must contain at least one observation.")
+        if not np.all(np.isfinite(filtering)):
+            raise ValueError("filtering_probabilities must contain only finite values.")
+        if not np.all(np.isfinite(predicted)):
+            raise ValueError("predicted_next_state_probabilities must contain only finite values.")
+        if not np.all(np.isfinite(expected)):
+            raise ValueError("expected_next_returns must contain only finite values.")
+        if not np.allclose(filtering.sum(axis=1), 1.0):
+            raise ValueError("filtering_probabilities rows must sum to 1.")
+        if not np.allclose(predicted.sum(axis=1), 1.0):
+            raise ValueError("predicted_next_state_probabilities rows must sum to 1.")
+        if not np.isfinite(self.log_likelihood):
+            raise ValueError("log_likelihood must be finite.")
+
+        for array in (filtering, predicted, expected):
+            array.setflags(write=False)
+
+        object.__setattr__(self, "filtering_probabilities", filtering)
+        object.__setattr__(self, "predicted_next_state_probabilities", predicted)
+        object.__setattr__(self, "expected_next_returns", expected)
+
+
+def forward_filter(
+    returns: pd.Series | np.ndarray,
+    model: GaussianHMMResult,
+) -> ForwardFilterResult:
+    """Run the normalized log-space forward recursion for a fitted Gaussian HMM.
+
+    The returned filtering probabilities are normalized at each time step to
+    prevent numerical underflow on long sequences. Expected next returns are
+    computed as ``P(m_{t+1} | Δy_{1:t}) @ μ``, where ``μ`` is the canonical
+    state-mean vector from ``model``.
+
+    References: §6 forward filtering and one-step-ahead prediction
+    """
+
+    observations = _coerce_returns(returns)
+    log_emissions = _gaussian_log_emissions(
+        observations,
+        means=model.means,
+        variances=model.variances,
+    )
+
+    with np.errstate(divide="ignore"):
+        log_start = np.log(model.initial_distribution)
+        log_transition = np.log(model.transition_matrix)
+
+    n_obs, k = log_emissions.shape
+    log_filtering = np.empty((n_obs, k), dtype=float)
+    log_normalizers = np.empty(n_obs, dtype=float)
+
+    initial_log_alpha = log_start + log_emissions[0]
+    initial_log_normalizer = float(logsumexp(initial_log_alpha))
+    log_filtering[0] = initial_log_alpha - initial_log_normalizer
+    log_normalizers[0] = initial_log_normalizer
+
+    for t in range(1, n_obs):
+        log_predicted = logsumexp(log_filtering[t - 1][:, None] + log_transition, axis=0)
+        log_alpha = log_emissions[t] + log_predicted
+        log_normalizer = float(logsumexp(log_alpha))
+        log_filtering[t] = log_alpha - log_normalizer
+        log_normalizers[t] = log_normalizer
+
+    filtering = np.exp(log_filtering)
+    predicted_next = filtering @ model.transition_matrix
+    expected_next_returns = predicted_next @ model.means
+    log_likelihood = float(log_normalizers.sum())
+
+    return ForwardFilterResult(
+        state_grid=model.state_grid,
+        filtering_probabilities=filtering,
+        predicted_next_state_probabilities=predicted_next,
+        expected_next_returns=expected_next_returns,
+        log_likelihood=log_likelihood,
+    )
+
+
+def _coerce_returns(returns: pd.Series | np.ndarray) -> np.ndarray:
+    values = np.asarray(returns, dtype=float)
+    if values.ndim != 1:
+        raise ValueError(f"returns must be one-dimensional, got shape {values.shape}.")
+    if values.size == 0:
+        raise ValueError("returns must contain at least one observation.")
+    if not np.all(np.isfinite(values)):
+        raise ValueError("returns must contain only finite values; drop NaN/inf first.")
+    return values
+
+
+def _gaussian_log_emissions(
+    returns: np.ndarray,
+    *,
+    means: np.ndarray,
+    variances: np.ndarray,
+) -> np.ndarray:
+    if returns.ndim != 1:
+        raise ValueError(f"returns must be one-dimensional, got shape {returns.shape}.")
+    if means.ndim != 1:
+        raise ValueError(f"means must be one-dimensional, got shape {means.shape}.")
+    if variances.shape != means.shape:
+        raise ValueError(
+            f"variances must have shape {means.shape}, got {variances.shape}."
+        )
+
+    centered = returns[:, None] - means[None, :]
+    log_emissions = -0.5 * (
+        np.log(2.0 * np.pi * variances[None, :]) + (centered * centered) / variances[None, :]
+    )
+    return np.asarray(log_emissions, dtype=float)

--- a/src/hft_hmm/inference/forward_filter.py
+++ b/src/hft_hmm/inference/forward_filter.py
@@ -108,6 +108,8 @@ def forward_filter(
     )
 
     with np.errstate(divide="ignore"):
+        # Zero-probability entries map to -inf under log; this is expected and
+        # downstream logsumexp handles those values safely.
         log_start = np.log(model.initial_distribution)
         log_transition = np.log(model.transition_matrix)
 
@@ -139,6 +141,15 @@ def forward_filter(
         expected_next_returns=expected_next_returns,
         log_likelihood=log_likelihood,
     )
+
+
+def filter_from_result(
+    fitted: GaussianHMMResult,
+    returns: pd.Series | np.ndarray,
+) -> ForwardFilterResult:
+    """Convenience wrapper that filters using a fitted Gaussian-HMM result."""
+
+    return forward_filter(returns, model=fitted)
 
 
 def _coerce_returns(returns: pd.Series | np.ndarray) -> np.ndarray:

--- a/src/hft_hmm/inference/forward_filter.py
+++ b/src/hft_hmm/inference/forward_filter.py
@@ -163,9 +163,7 @@ def _gaussian_log_emissions(
     if means.ndim != 1:
         raise ValueError(f"means must be one-dimensional, got shape {means.shape}.")
     if variances.shape != means.shape:
-        raise ValueError(
-            f"variances must have shape {means.shape}, got {variances.shape}."
-        )
+        raise ValueError(f"variances must have shape {means.shape}, got {variances.shape}.")
 
     centered = returns[:, None] - means[None, :]
     log_emissions = -0.5 * (

--- a/tests/test_forward_filter.py
+++ b/tests/test_forward_filter.py
@@ -6,9 +6,12 @@ import importlib
 
 import numpy as np
 import pytest
+from hmmlearn import _hmmc
+from hmmlearn.hmm import GaussianHMM
+from scipy.special import logsumexp
 
 from hft_hmm.core import PAPER_FAITHFUL, StateGrid, module_category
-from hft_hmm.inference import ForwardFilterResult, forward_filter
+from hft_hmm.inference import ForwardFilterResult, filter_from_result, forward_filter
 from hft_hmm.models.gaussian_hmm import GaussianHMMResult
 
 forward_filter_module = importlib.import_module("hft_hmm.inference.forward_filter")
@@ -75,6 +78,53 @@ def test_forward_filter_matches_manual_first_step_posterior() -> None:
     np.testing.assert_allclose(result.filtering_probabilities[0], posterior)
 
 
+def test_filter_from_result_wrapper_matches_forward_filter() -> None:
+    fitted = _toy_model()
+    returns = np.array([-1.2, -0.8, 0.9, 1.1], dtype=float)
+
+    wrapped = filter_from_result(fitted, returns)
+    direct = forward_filter(returns, model=fitted)
+
+    np.testing.assert_allclose(wrapped.filtering_probabilities, direct.filtering_probabilities)
+    np.testing.assert_allclose(
+        wrapped.predicted_next_state_probabilities,
+        direct.predicted_next_state_probabilities,
+    )
+    np.testing.assert_allclose(wrapped.expected_next_returns, direct.expected_next_returns)
+    assert np.isclose(wrapped.log_likelihood, direct.log_likelihood)
+
+
+def test_forward_filter_matches_hmmlearn_reference() -> None:
+    fitted = _toy_model()
+    rng = np.random.default_rng(0)
+    returns = rng.normal(size=500)
+    observations = returns.reshape(-1, 1)
+
+    ref = GaussianHMM(
+        n_components=fitted.state_grid.k,
+        covariance_type="diag",
+        implementation="log",
+    )
+    ref.startprob_ = fitted.initial_distribution
+    ref.transmat_ = fitted.transition_matrix
+    ref.means_ = fitted.means.reshape(-1, 1)
+    ref.covars_ = fitted.variances.reshape(-1, 1)
+
+    result = forward_filter(returns, model=fitted)
+    log_frameprob = ref._compute_log_likelihood(observations)
+    _, forward_log_lattice = _hmmc.forward_log(ref.startprob_, ref.transmat_, log_frameprob)
+    forward_probabilities = np.exp(
+        forward_log_lattice - logsumexp(forward_log_lattice, axis=1, keepdims=True)
+    )
+
+    np.testing.assert_allclose(
+        result.filtering_probabilities,
+        forward_probabilities,
+        atol=1e-10,
+    )
+    assert np.isclose(result.log_likelihood, ref.score(observations), atol=1e-8)
+
+
 def test_forward_filter_rejects_invalid_returns() -> None:
     model = _toy_model()
 
@@ -97,5 +147,8 @@ def test_forward_filter_stays_finite_on_long_sequence() -> None:
     assert np.all(np.isfinite(result.predicted_next_state_probabilities))
     assert np.all(np.isfinite(result.expected_next_returns))
     assert np.isfinite(result.log_likelihood)
+    per_step_ll = result.log_likelihood / returns.size
+    assert np.isfinite(per_step_ll)
+    assert -10.0 < per_step_ll < 0.0
     assert np.allclose(result.filtering_probabilities.sum(axis=1), 1.0)
     assert np.allclose(result.predicted_next_state_probabilities.sum(axis=1), 1.0)

--- a/tests/test_forward_filter.py
+++ b/tests/test_forward_filter.py
@@ -1,0 +1,101 @@
+"""Tests for the log-space Gaussian-HMM forward filter."""
+
+from __future__ import annotations
+
+import importlib
+
+import numpy as np
+import pytest
+
+from hft_hmm.core import PAPER_FAITHFUL, StateGrid, module_category
+from hft_hmm.inference import ForwardFilterResult, forward_filter
+from hft_hmm.models.gaussian_hmm import GaussianHMMResult
+
+forward_filter_module = importlib.import_module("hft_hmm.inference.forward_filter")
+
+
+def _toy_model() -> GaussianHMMResult:
+    means = np.array([-1.0, 1.0], dtype=float)
+    variances = np.array([0.1, 0.1], dtype=float)
+    transition_matrix = np.array([[0.95, 0.05], [0.05, 0.95]], dtype=float)
+    initial_distribution = np.array([0.5, 0.5], dtype=float)
+    return GaussianHMMResult(
+        state_grid=StateGrid(k=2, means=means, labels=("down", "up")),
+        means=means,
+        variances=variances,
+        transition_matrix=transition_matrix,
+        initial_distribution=initial_distribution,
+        log_likelihood=0.0,
+        n_observations=4,
+        converged=True,
+        n_iter=10,
+        random_state=0,
+    )
+
+
+def test_forward_filter_module_declares_paper_faithful_category() -> None:
+    assert module_category(forward_filter_module) == PAPER_FAITHFUL
+
+
+def test_forward_filter_returns_normalized_probabilities_and_expected_returns() -> None:
+    model = _toy_model()
+    returns = np.array([-1.2, -0.8, 0.9, 1.1], dtype=float)
+
+    result = forward_filter(returns, model)
+
+    assert isinstance(result, ForwardFilterResult)
+    assert result.filtering_probabilities.shape == (4, 2)
+    assert result.predicted_next_state_probabilities.shape == (4, 2)
+    assert result.expected_next_returns.shape == (4,)
+    assert np.allclose(result.filtering_probabilities.sum(axis=1), 1.0)
+    assert np.allclose(result.predicted_next_state_probabilities.sum(axis=1), 1.0)
+    assert result.filtering_probabilities[0, 0] > result.filtering_probabilities[0, 1]
+    assert result.filtering_probabilities[-1, 1] > result.filtering_probabilities[-1, 0]
+    assert result.expected_next_returns[0] < 0.0
+    assert result.expected_next_returns[-1] > 0.0
+    assert np.isfinite(result.log_likelihood)
+
+
+def test_forward_filter_matches_manual_first_step_posterior() -> None:
+    model = _toy_model()
+    returns = np.array([-1.0], dtype=float)
+
+    result = forward_filter(returns, model)
+
+    emission = np.exp(
+        -0.5
+        * (
+            np.log(2.0 * np.pi * model.variances)
+            + ((returns[0] - model.means) ** 2) / model.variances
+        )
+    )
+    posterior = model.initial_distribution * emission
+    posterior = posterior / posterior.sum()
+
+    np.testing.assert_allclose(result.filtering_probabilities[0], posterior)
+
+
+def test_forward_filter_rejects_invalid_returns() -> None:
+    model = _toy_model()
+
+    with pytest.raises(ValueError, match="one-dimensional"):
+        forward_filter(np.zeros((3, 2)), model)
+    with pytest.raises(ValueError, match="at least one observation"):
+        forward_filter(np.array([], dtype=float), model)
+    with pytest.raises(ValueError, match="finite"):
+        forward_filter(np.array([0.0, np.nan]), model)
+
+
+def test_forward_filter_stays_finite_on_long_sequence() -> None:
+    model = _toy_model()
+    returns = np.tile(np.array([-0.95, 0.95], dtype=float), 3000)
+
+    result = forward_filter(returns, model)
+
+    assert result.filtering_probabilities.shape == (6000, 2)
+    assert np.all(np.isfinite(result.filtering_probabilities))
+    assert np.all(np.isfinite(result.predicted_next_state_probabilities))
+    assert np.all(np.isfinite(result.expected_next_returns))
+    assert np.isfinite(result.log_likelihood)
+    assert np.allclose(result.filtering_probabilities.sum(axis=1), 1.0)
+    assert np.allclose(result.predicted_next_state_probabilities.sum(axis=1), 1.0)


### PR DESCRIPTION
## Summary
- Adds `hft_hmm.inference.forward_filter` with a log-space forward recursion (via `scipy.special.logsumexp`) that stays finite on long sequences.
- Returns a frozen `ForwardFilterResult` with filtering probabilities, one-step-ahead predicted state probabilities, expected next returns, and the log-likelihood.
- Declares the module `PAPER_FAITHFUL` and wires exports through `hft_hmm.inference` and the package root.

Closes #17 (Gate D).

## Test plan
- [x] `pytest tests/test_forward_filter.py` — 5 tests covering category metadata, normalization, manual first-step posterior parity, input validation, and long-sequence stability (T=6000).
- [x] Full suite: `pytest` → 137 passed.
- [x] `ruff check src tests`, `black --check src tests`, `mypy src` all clean.

## Out of scope
- Backward / smoothing pass and Viterbi decoding.
- Side-information conditioning (Gate H).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Forward filtering for HMM models now available, computing filtered state probabilities at each observation, predicted next-state distributions, expected returns forecasts, and model log-likelihood
  * New inference utilities integrated into the main package API with comprehensive input validation and numerical stability for analyzing extended observation sequences reliably

<!-- end of auto-generated comment: release notes by coderabbit.ai -->