### PR TITLE
feat(strategy): sign-based trading signal and alignment helper (Issue 09)

### DIFF
--- a/src/hft_hmm/__init__.py
+++ b/src/hft_hmm/__init__.py
@@ -42,6 +42,7 @@ from hft_hmm.selection import (
     plot_selection_curves,
 )
 from hft_hmm.strategy import (
+    SIGNAL_REFERENCE,
     align_signal_with_future_return,
     sign_signal,
     signal_from_filter_result,
@@ -54,6 +55,7 @@ __all__ = [
     "EVALUATION_LAYER",
     "PAPER_FAITHFUL",
     "PROJECT_NAME",
+    "SIGNAL_REFERENCE",
     "ForwardFilterResult",
     "GaussianHMMResult",
     "GaussianHMMWrapper",

--- a/src/hft_hmm/__init__.py
+++ b/src/hft_hmm/__init__.py
@@ -41,6 +41,12 @@ from hft_hmm.selection import (
     count_gaussian_hmm_parameters,
     plot_selection_curves,
 )
+from hft_hmm.strategy import (
+    align_signal_with_future_return,
+    sign_signal,
+    signal_from_filter_result,
+    thresholded_signal,
+)
 
 __all__ = [
     "ALL_CATEGORIES",
@@ -63,6 +69,7 @@ __all__ = [
     "StateGrid",
     "__version__",
     "aic",
+    "align_signal_with_future_return",
     "bic",
     "compare_state_counts",
     "compute_log_returns",
@@ -80,6 +87,9 @@ __all__ = [
     "plot_selection_curves",
     "reference",
     "resample_prices",
+    "sign_signal",
+    "signal_from_filter_result",
+    "thresholded_signal",
     "train_test_split_time",
     "validate_market_data",
 ]

--- a/src/hft_hmm/strategy/__init__.py
+++ b/src/hft_hmm/strategy/__init__.py
@@ -1,0 +1,17 @@
+"""Signal generation and trading policy utilities."""
+
+from hft_hmm.strategy.signals import (
+    SIGNAL_REFERENCE,
+    align_signal_with_future_return,
+    sign_signal,
+    signal_from_filter_result,
+    thresholded_signal,
+)
+
+__all__ = [
+    "SIGNAL_REFERENCE",
+    "align_signal_with_future_return",
+    "sign_signal",
+    "signal_from_filter_result",
+    "thresholded_signal",
+]

--- a/src/hft_hmm/strategy/signals.py
+++ b/src/hft_hmm/strategy/signals.py
@@ -164,6 +164,7 @@ def _coerce_expected_returns(
     expected_next_returns: pd.Series | np.ndarray,
 ) -> tuple[np.ndarray, pd.Index]:
     if isinstance(expected_next_returns, pd.Series):
+        # pd.Series is inherently 1-D; only non-Series inputs need an explicit ndim check.
         values = np.asarray(expected_next_returns, dtype=float)
         index: pd.Index = expected_next_returns.index
     else:

--- a/src/hft_hmm/strategy/signals.py
+++ b/src/hft_hmm/strategy/signals.py
@@ -1,0 +1,182 @@
+"""Signal generation and alignment for HMM-driven trading.
+
+Evaluation layer — turns the one-step-ahead expected returns produced by the
+forward filter into a simple long/short/flat position and provides the
+alignment helper that maps a signal to its realized next-bar return without
+leaking future information.
+
+Conventions
+-----------
+- ``signal[t]`` is the position chosen using information available at bar
+  ``t`` (``Δy_{1:t}``) and held from bar ``t`` to bar ``t+1``.
+- Realized per-bar strategy return at bar ``t`` is
+  ``signal[t-1] * realized_returns[t]``; ``align_signal_with_future_return``
+  enforces this alignment and drops the first bar.
+- ``ForwardFilterResult.expected_next_returns[t]`` is ``E[Δy_{t+1} | Δy_{1:t}]``
+  (see ``hft_hmm.inference.forward_filter``), so feeding that array straight
+  into ``sign_signal`` is consistent with the convention above; no ``shift``
+  is required.
+
+Evaluation modes
+----------------
+- **no-cost**: aggregate metrics are computed on ``signal[t-1] * returns[t]``
+  with no adjustment.
+- **cost-aware**: a turnover cost ``c`` (basis points per position change)
+  is subtracted when computing post-cost metrics. The cost model itself
+  lives in the Gate E metrics module (Issue 10); this module only emits
+  signals and does not apply costs, so its output is identical in both
+  modes.
+
+References: §8 sign-based trading signal (evaluation layer)
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+import numpy as np
+import pandas as pd
+
+from hft_hmm.core import EVALUATION_LAYER, PaperReference, reference
+from hft_hmm.inference import ForwardFilterResult
+
+__category__: Final[str] = EVALUATION_LAYER
+SIGNAL_REFERENCE: Final[PaperReference] = reference(
+    "§8", "sign-based trading signal from expected return"
+)
+
+
+def sign_signal(expected_next_returns: pd.Series | np.ndarray) -> pd.Series:
+    """Return +1/-1/0 positions from one-step-ahead expected returns.
+
+    ``signal[t]`` is the sign of ``E[Δy_{t+1} | Δy_{1:t}]``: ``+1`` when the
+    expected next return is strictly positive, ``-1`` when strictly negative,
+    and ``0`` when exactly zero. The output is a ``pd.Series`` of ``int8``
+    preserving the input index, or a positional ``RangeIndex`` for raw numpy
+    input.
+
+    References: §8 sign-based trading signal (evaluation layer)
+    """
+    values, index = _coerce_expected_returns(expected_next_returns)
+    signal = np.sign(values).astype(np.int8, copy=False)
+    return pd.Series(signal, index=index, name="signal")
+
+
+def thresholded_signal(
+    expected_next_returns: pd.Series | np.ndarray,
+    *,
+    threshold: float,
+) -> pd.Series:
+    """Sign-with-deadzone signal over absolute expected return.
+
+    ``signal[t]`` is ``+1`` when ``E[Δy_{t+1}] >  threshold``, ``-1`` when
+    ``E[Δy_{t+1}] < -threshold``, and ``0`` inside the dead-zone
+    ``|E[Δy_{t+1}]| <= threshold``. ``threshold`` is expressed in log-return
+    units, must be a finite non-negative float, and ``threshold=0`` reproduces
+    ``sign_signal``.
+
+    References: §8 sign-based trading signal (evaluation layer)
+    """
+    if not np.isfinite(threshold) or threshold < 0.0:
+        raise ValueError(f"threshold must be a finite non-negative float, got {threshold!r}.")
+    values, index = _coerce_expected_returns(expected_next_returns)
+    signal = np.zeros_like(values, dtype=np.int8)
+    signal[values > threshold] = 1
+    signal[values < -threshold] = -1
+    return pd.Series(signal, index=index, name="signal")
+
+
+def signal_from_filter_result(
+    result: ForwardFilterResult,
+    *,
+    threshold: float = 0.0,
+    index: pd.Index | None = None,
+) -> pd.Series:
+    """Convenience wrapper that builds a thresholded signal from a filter result.
+
+    ``result.expected_next_returns`` is a plain numpy array, so callers that
+    want to preserve their return-series index should pass it via ``index``.
+    With ``threshold=0`` this reduces to ``sign_signal``.
+
+    References: §8 sign-based trading signal (evaluation layer)
+    """
+    source: pd.Series | np.ndarray = result.expected_next_returns
+    if index is not None:
+        if len(index) != result.expected_next_returns.shape[0]:
+            raise ValueError(
+                "index length must match expected_next_returns; "
+                f"got {len(index)} vs {result.expected_next_returns.shape[0]}."
+            )
+        source = pd.Series(result.expected_next_returns, index=index)
+    return thresholded_signal(source, threshold=threshold)
+
+
+def align_signal_with_future_return(
+    signal: pd.Series,
+    realized_returns: pd.Series,
+) -> pd.Series:
+    """Return ``signal[t-1] * realized_returns[t]`` indexed at bar ``t``.
+
+    The two Series must share an index; sharing the index is the primary
+    guard against accidental shift mistakes upstream. The output is indexed
+    at the realization bar and drops the first observation (which has no
+    preceding signal), so the caller can compute strategy returns without
+    further shifting. Inputs must be fully finite — drop NaN from realized
+    returns before calling.
+
+    References: §8 sign-based trading signal (evaluation layer)
+    """
+    if not isinstance(signal, pd.Series):
+        raise TypeError(f"signal must be a pd.Series, got {type(signal).__name__}.")
+    if not isinstance(realized_returns, pd.Series):
+        raise TypeError(
+            f"realized_returns must be a pd.Series, got {type(realized_returns).__name__}."
+        )
+    if len(signal) != len(realized_returns):
+        raise ValueError(
+            "signal and realized_returns must have the same length; "
+            f"got {len(signal)} vs {len(realized_returns)}."
+        )
+    if not signal.index.equals(realized_returns.index):
+        raise ValueError(
+            "signal and realized_returns must share the same index; "
+            "align both to the same timeline before calling this helper."
+        )
+    if len(signal) < 2:
+        raise ValueError("at least two observations are required to align signal with returns.")
+
+    signal_values = np.asarray(signal, dtype=float)
+    return_values = np.asarray(realized_returns, dtype=float)
+    if not np.all(np.isfinite(signal_values)):
+        raise ValueError("signal must contain only finite values.")
+    if not np.all(np.isfinite(return_values)):
+        raise ValueError("realized_returns must contain only finite values; drop NaN/inf first.")
+
+    realized = signal_values[:-1] * return_values[1:]
+    return pd.Series(
+        realized,
+        index=realized_returns.index[1:],
+        name="strategy_return",
+    )
+
+
+def _coerce_expected_returns(
+    expected_next_returns: pd.Series | np.ndarray,
+) -> tuple[np.ndarray, pd.Index]:
+    if isinstance(expected_next_returns, pd.Series):
+        values = np.asarray(expected_next_returns, dtype=float)
+        index: pd.Index = expected_next_returns.index
+    else:
+        values = np.asarray(expected_next_returns, dtype=float)
+        if values.ndim != 1:
+            raise ValueError(
+                "expected_next_returns must be one-dimensional, " f"got shape {values.shape}."
+            )
+        index = pd.RangeIndex(values.shape[0])
+    if values.size == 0:
+        raise ValueError("expected_next_returns must contain at least one observation.")
+    if not np.all(np.isfinite(values)):
+        raise ValueError(
+            "expected_next_returns must contain only finite values; drop NaN/inf first."
+        )
+    return values, index

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -191,13 +191,14 @@ def test_align_leakage_probe_does_not_peek_into_future() -> None:
 
     # Wrong (same-bar) and wrong (future-peek) must not match the output.
     wrong_same_bar = (signal * returns).iloc[1:].to_numpy().astype(float)
-    wrong_future_peek = (signal.iloc[:-1].to_numpy() * returns.iloc[1:].to_numpy()).astype(float)
-    # The future-peek alignment happens to coincide with the correct one here
-    # because of how we align (signal[t-1] matches signal[:-1]); the test of
-    # record is that the *same-bar* wrong alignment is distinguishable.
+    wrong_future_peek = (signal.iloc[1:].to_numpy() * returns.iloc[:-1].to_numpy()).astype(float)
+    canonical_prev_signal = (signal.iloc[:-1].to_numpy() * returns.iloc[1:].to_numpy()).astype(
+        float
+    )
     assert not np.allclose(aligned.to_numpy(), wrong_same_bar)
+    assert not np.allclose(aligned.to_numpy(), wrong_future_peek)
     # Sanity: the helper matches the canonical vectorized expression.
-    np.testing.assert_allclose(aligned.to_numpy(), wrong_future_peek)
+    np.testing.assert_allclose(aligned.to_numpy(), canonical_prev_signal)
 
 
 def test_signal_from_filter_result_matches_sign_on_expected_returns() -> None:

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,0 +1,280 @@
+"""Tests for signal generation and alignment helpers."""
+
+from __future__ import annotations
+
+import importlib
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from hft_hmm.core import EVALUATION_LAYER, StateGrid, module_category
+from hft_hmm.inference import forward_filter
+from hft_hmm.models.gaussian_hmm import GaussianHMMResult
+from hft_hmm.strategy import (
+    align_signal_with_future_return,
+    sign_signal,
+    signal_from_filter_result,
+    thresholded_signal,
+)
+
+signals_module = importlib.import_module("hft_hmm.strategy.signals")
+
+
+def _toy_model() -> GaussianHMMResult:
+    means = np.array([-1.0, 1.0], dtype=float)
+    variances = np.array([0.1, 0.1], dtype=float)
+    transition_matrix = np.array([[0.95, 0.05], [0.05, 0.95]], dtype=float)
+    initial_distribution = np.array([0.5, 0.5], dtype=float)
+    return GaussianHMMResult(
+        state_grid=StateGrid(k=2, means=means, labels=("down", "up")),
+        means=means,
+        variances=variances,
+        transition_matrix=transition_matrix,
+        initial_distribution=initial_distribution,
+        log_likelihood=0.0,
+        n_observations=4,
+        converged=True,
+        n_iter=10,
+        random_state=0,
+    )
+
+
+def test_signals_module_declares_evaluation_layer_category() -> None:
+    assert module_category(signals_module) == EVALUATION_LAYER
+
+
+def test_sign_signal_maps_sign_on_ndarray() -> None:
+    values = np.array([-0.1, 0.0, 0.05, -0.02, 1e-9], dtype=float)
+
+    signal = sign_signal(values)
+
+    assert isinstance(signal, pd.Series)
+    assert signal.dtype == np.int8
+    assert signal.name == "signal"
+    assert isinstance(signal.index, pd.RangeIndex)
+    np.testing.assert_array_equal(signal.to_numpy(), np.array([-1, 0, 1, -1, 1]))
+
+
+def test_sign_signal_preserves_series_index() -> None:
+    index = pd.date_range("2024-01-01", periods=4, freq="1min")
+    series = pd.Series([0.01, -0.02, 0.0, 0.03], index=index)
+
+    signal = sign_signal(series)
+
+    assert signal.index.equals(index)
+    np.testing.assert_array_equal(signal.to_numpy(), np.array([1, -1, 0, 1]))
+
+
+def test_sign_signal_rejects_invalid_input() -> None:
+    with pytest.raises(ValueError, match="one-dimensional"):
+        sign_signal(np.zeros((3, 2)))
+    with pytest.raises(ValueError, match="at least one"):
+        sign_signal(np.array([], dtype=float))
+    with pytest.raises(ValueError, match="finite"):
+        sign_signal(np.array([0.1, np.nan, 0.2]))
+
+
+def test_thresholded_signal_matches_sign_at_zero_threshold() -> None:
+    values = np.array([-0.1, 0.0, 0.05, -0.02], dtype=float)
+
+    thresholded = thresholded_signal(values, threshold=0.0)
+    sign = sign_signal(values)
+
+    np.testing.assert_array_equal(thresholded.to_numpy(), sign.to_numpy())
+
+
+def test_thresholded_signal_enforces_dead_zone() -> None:
+    values = np.array([-0.05, -0.01, 0.0, 0.01, 0.05, 0.15], dtype=float)
+
+    signal = thresholded_signal(values, threshold=0.02)
+
+    np.testing.assert_array_equal(signal.to_numpy(), np.array([-1, 0, 0, 0, 1, 1]))
+
+
+def test_thresholded_signal_boundary_is_flat() -> None:
+    values = np.array([-0.02, -0.019, 0.019, 0.02], dtype=float)
+
+    signal = thresholded_signal(values, threshold=0.02)
+
+    np.testing.assert_array_equal(signal.to_numpy(), np.array([0, 0, 0, 0]))
+
+
+def test_thresholded_signal_rejects_negative_or_non_finite_threshold() -> None:
+    values = np.array([0.01, -0.02, 0.03], dtype=float)
+
+    with pytest.raises(ValueError, match="non-negative"):
+        thresholded_signal(values, threshold=-0.01)
+    with pytest.raises(ValueError, match="finite"):
+        thresholded_signal(values, threshold=float("inf"))
+    with pytest.raises(ValueError, match="finite"):
+        thresholded_signal(values, threshold=float("nan"))
+
+
+def test_align_signal_with_future_return_uses_previous_signal() -> None:
+    index = pd.RangeIndex(4)
+    signal = pd.Series([0, 1, -1, 1], index=index)
+    returns = pd.Series([10.0, 20.0, 30.0, 40.0], index=index)
+
+    aligned = align_signal_with_future_return(signal, returns)
+
+    assert aligned.name == "strategy_return"
+    np.testing.assert_array_equal(aligned.index.to_numpy(), np.array([1, 2, 3]))
+    np.testing.assert_allclose(aligned.to_numpy(), np.array([0.0, 30.0, -40.0]))
+
+
+def test_align_rejects_mismatched_index() -> None:
+    signal = pd.Series([1, -1, 1], index=[0, 1, 2])
+    returns = pd.Series([0.1, 0.2, 0.3], index=[10, 11, 12])
+
+    with pytest.raises(ValueError, match="same index"):
+        align_signal_with_future_return(signal, returns)
+
+
+def test_align_rejects_mismatched_length() -> None:
+    signal = pd.Series([1, -1], index=[0, 1])
+    returns = pd.Series([0.1, 0.2, 0.3], index=[0, 1, 2])
+
+    with pytest.raises(ValueError, match="same length"):
+        align_signal_with_future_return(signal, returns)
+
+
+def test_align_rejects_non_series_inputs() -> None:
+    returns = pd.Series([0.1, 0.2], index=[0, 1])
+
+    with pytest.raises(TypeError, match="signal"):
+        align_signal_with_future_return([1, -1], returns)  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="realized_returns"):
+        align_signal_with_future_return(returns, np.array([0.1, 0.2]))  # type: ignore[arg-type]
+
+
+def test_align_rejects_single_observation() -> None:
+    signal = pd.Series([1], index=[0])
+    returns = pd.Series([0.1], index=[0])
+
+    with pytest.raises(ValueError, match="at least two"):
+        align_signal_with_future_return(signal, returns)
+
+
+def test_align_rejects_non_finite_inputs() -> None:
+    index = pd.RangeIndex(3)
+    signal = pd.Series([1, -1, 1], index=index)
+    returns_nan = pd.Series([0.1, np.nan, 0.3], index=index)
+    signal_inf = pd.Series([1.0, float("inf"), 1.0], index=index)
+    returns = pd.Series([0.1, 0.2, 0.3], index=index)
+
+    with pytest.raises(ValueError, match="realized_returns must contain only finite"):
+        align_signal_with_future_return(signal, returns_nan)
+    with pytest.raises(ValueError, match="signal must contain only finite"):
+        align_signal_with_future_return(signal_inf, returns)
+
+
+def test_align_leakage_probe_does_not_peek_into_future() -> None:
+    """The helper must compute signal[t-1]*returns[t], never signal[t]*returns[t+1]."""
+    index = pd.RangeIndex(5)
+    signal = pd.Series([1, -1, 1, -1, 1], index=index)
+    returns = pd.Series([1.0, 2.0, 4.0, 8.0, 16.0], index=index)
+
+    aligned = align_signal_with_future_return(signal, returns)
+
+    # Correct: signal[t-1] * returns[t]
+    expected_correct = np.array(
+        [
+            signal.iloc[0] * returns.iloc[1],
+            signal.iloc[1] * returns.iloc[2],
+            signal.iloc[2] * returns.iloc[3],
+            signal.iloc[3] * returns.iloc[4],
+        ],
+        dtype=float,
+    )
+    np.testing.assert_allclose(aligned.to_numpy(), expected_correct)
+
+    # Wrong (same-bar) and wrong (future-peek) must not match the output.
+    wrong_same_bar = (signal * returns).iloc[1:].to_numpy().astype(float)
+    wrong_future_peek = (signal.iloc[:-1].to_numpy() * returns.iloc[1:].to_numpy()).astype(float)
+    # The future-peek alignment happens to coincide with the correct one here
+    # because of how we align (signal[t-1] matches signal[:-1]); the test of
+    # record is that the *same-bar* wrong alignment is distinguishable.
+    assert not np.allclose(aligned.to_numpy(), wrong_same_bar)
+    # Sanity: the helper matches the canonical vectorized expression.
+    np.testing.assert_allclose(aligned.to_numpy(), wrong_future_peek)
+
+
+def test_signal_from_filter_result_matches_sign_on_expected_returns() -> None:
+    model = _toy_model()
+    returns = np.array([-1.2, -0.8, 0.9, 1.1], dtype=float)
+
+    filter_result = forward_filter(returns, model)
+    via_wrapper = signal_from_filter_result(filter_result)
+    via_sign = sign_signal(filter_result.expected_next_returns)
+
+    np.testing.assert_array_equal(via_wrapper.to_numpy(), via_sign.to_numpy())
+    assert isinstance(via_wrapper.index, pd.RangeIndex)
+
+
+def test_signal_from_filter_result_preserves_supplied_index() -> None:
+    model = _toy_model()
+    returns = np.array([-1.2, -0.8, 0.9, 1.1], dtype=float)
+    index = pd.date_range("2024-01-01 09:30", periods=4, freq="1min")
+
+    filter_result = forward_filter(returns, model)
+    signal = signal_from_filter_result(filter_result, index=index)
+
+    assert signal.index.equals(index)
+
+
+def test_signal_from_filter_result_rejects_mismatched_index() -> None:
+    model = _toy_model()
+    returns = np.array([-1.2, -0.8, 0.9, 1.1], dtype=float)
+    bad_index = pd.RangeIndex(3)  # wrong length
+
+    filter_result = forward_filter(returns, model)
+    with pytest.raises(ValueError, match="index length"):
+        signal_from_filter_result(filter_result, index=bad_index)
+
+
+def test_signal_from_filter_result_applies_threshold() -> None:
+    model = _toy_model()
+    returns = np.array([-1.2, -0.8, 0.9, 1.1], dtype=float)
+
+    filter_result = forward_filter(returns, model)
+    thresholded = signal_from_filter_result(filter_result, threshold=10.0)
+
+    # Threshold above any plausible expected return collapses to all-zero.
+    np.testing.assert_array_equal(thresholded.to_numpy(), np.zeros(4, dtype=np.int8))
+
+
+def test_sign_signal_tracks_toy_hmm_regime() -> None:
+    model = _toy_model()
+    returns = np.array([-1.2, -0.8, 0.9, 1.1], dtype=float)
+
+    filter_result = forward_filter(returns, model)
+    signal = sign_signal(filter_result.expected_next_returns)
+
+    # Strongly persistent two-state model: down observations → short;
+    # up observations → long.
+    assert signal.iloc[0] == -1
+    assert signal.iloc[1] == -1
+    assert signal.iloc[-1] == 1
+
+
+def test_align_integrates_with_forward_filter_pipeline() -> None:
+    model = _toy_model()
+    index = pd.date_range("2024-01-01 09:30", periods=4, freq="1min")
+    returns_series = pd.Series([-1.2, -0.8, 0.9, 1.1], index=index)
+
+    filter_result = forward_filter(returns_series.to_numpy(), model)
+    signal = sign_signal(pd.Series(filter_result.expected_next_returns, index=index))
+    strategy = align_signal_with_future_return(signal, returns_series)
+
+    assert strategy.index.equals(index[1:])
+    # strategy[t] = signal[t-1] * returns[t]
+    expected = np.array(
+        [
+            signal.iloc[0] * returns_series.iloc[1],
+            signal.iloc[1] * returns_series.iloc[2],
+            signal.iloc[2] * returns_series.iloc[3],
+        ],
+        dtype=float,
+    )
+    np.testing.assert_allclose(strategy.to_numpy(), expected)


### PR DESCRIPTION
## Summary
- New `hft_hmm.strategy.signals` module (`EVALUATION_LAYER`) with `sign_signal`, `thresholded_signal`, `signal_from_filter_result`, and `align_signal_with_future_return`.
- Signal indexing: `signal[t]` uses information through bar `t`; realized strategy return at bar `t` is `signal[t-1] * returns[t]`. `ForwardFilterResult.expected_next_returns` feeds straight into `sign_signal` with no manual shift.
- Threshold is absolute (log-return units), non-negative, finite; `threshold=0` reproduces `sign_signal`. Cost-aware mode is deferred to Issue 10 per the module docstring — this module only emits signals.

## Issue / gate
Closes #9. Covers Gate E signal-layer checks (signal generation, alignment, no leakage). Gate E metrics (Issue 10) are a separate PR.

## Design notes
- **Category** `EVALUATION_LAYER` — decision layer over model outputs, not DGP reproduction.
- **Threshold units** absolute log-return. A volatility-normalized variant is noted as a possible Gate G follow-up, not added here.
- **Coupling** core functions take arrays/`Series` only; `signal_from_filter_result` is a thin convenience wrapper mirroring `filter_from_result` from Issue 08 so `strategy/` does not branch on model-specific result types (keeps Issue 16 IOHMM work clean).

## Test plan
- [x] `test_signals.py` — 21 tests, 100% coverage on `signals.py`
- [x] category tag, sign semantics on ndarray + Series with index preservation
- [x] thresholded dead-zone (inside, boundary, outside), threshold validation (negative, inf, NaN)
- [x] alignment correctness: `signal[t-1] * returns[t]` indexed at `t`, drops first bar
- [x] alignment guards: mismatched index, mismatched length, non-Series inputs, single observation, non-finite
- [x] leakage probe — explicit same-bar multiplication is distinguishable from the helper's output
- [x] integration: forward filter → `sign_signal` → alignment on the 2-state toy HMM
- [x] full suite `.venv/bin/pytest` — 160 passed
- [x] `.venv/bin/ruff check src tests` clean
- [x] `.venv/bin/black --check src tests` clean
- [x] `.venv/bin/mypy src` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added trading signal generation module with sign-based and threshold-based signal construction from HMM results. Includes utilities for temporal alignment of signals with realized returns. Expanded public API for signal processing functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->