### PR TITLE
feat(13): volatility-ratio side-information predictor

### DIFF
--- a/src/hft_hmm/__init__.py
+++ b/src/hft_hmm/__init__.py
@@ -46,6 +46,12 @@ from hft_hmm.experiments import (
     walk_forward,
 )
 from hft_hmm.experiments.runner import NON_REPRODUCIBLE_WARNING, RunArtifacts, run_experiment
+from hft_hmm.features import (
+    VOLATILITY_RATIO_REFERENCE,
+    VolatilityRatioConfig,
+    ewma_volatility,
+    volatility_ratio,
+)
 from hft_hmm.inference import ForwardFilterResult, filter_from_result, forward_filter
 from hft_hmm.models import (
     GaussianHMMResult,
@@ -84,6 +90,7 @@ __all__ = [
     "PAPER_FAITHFUL",
     "PROJECT_NAME",
     "SIGNAL_REFERENCE",
+    "VOLATILITY_RATIO_REFERENCE",
     "WALK_FORWARD_REFERENCE",
     "DataSourceConfig",
     "ExperimentConfig",
@@ -101,6 +108,7 @@ __all__ = [
     "ProjectInfo",
     "RunArtifacts",
     "StateGrid",
+    "VolatilityRatioConfig",
     "WalkForwardConfig",
     "WalkForwardResult",
     "WalkForwardWindow",
@@ -115,6 +123,7 @@ __all__ = [
     "count_gaussian_hmm_parameters",
     "cumulative_return",
     "default_labels",
+    "ewma_volatility",
     "fit_piecewise_linear_regression",
     "filter_from_result",
     "forward_filter",
@@ -139,5 +148,6 @@ __all__ = [
     "thresholded_signal",
     "train_test_split_time",
     "validate_market_data",
+    "volatility_ratio",
     "walk_forward",
 ]

--- a/src/hft_hmm/features/__init__.py
+++ b/src/hft_hmm/features/__init__.py
@@ -1,0 +1,15 @@
+"""Side-information feature modules used to bias HMM transition dynamics."""
+
+from hft_hmm.features.volatility_ratio import (
+    VOLATILITY_RATIO_REFERENCE,
+    VolatilityRatioConfig,
+    ewma_volatility,
+    volatility_ratio,
+)
+
+__all__ = [
+    "VOLATILITY_RATIO_REFERENCE",
+    "VolatilityRatioConfig",
+    "ewma_volatility",
+    "volatility_ratio",
+]

--- a/src/hft_hmm/features/volatility_ratio.py
+++ b/src/hft_hmm/features/volatility_ratio.py
@@ -83,8 +83,10 @@ def ewma_volatility(
         raise TypeError(f"returns must be a pandas Series, got {type(returns).__name__}.")
 
     values = returns.to_numpy(dtype=float)
-    if np.isnan(values).any():
-        raise ValueError("returns must not contain NaN; drop missing values before calling.")
+    if not np.isfinite(values).all():
+        raise ValueError(
+            "returns must be finite; drop or mask non-finite values before calling."
+        )
 
     squared = values**2
     sigma = np.full(values.shape[0], np.nan, dtype=float)

--- a/src/hft_hmm/features/volatility_ratio.py
+++ b/src/hft_hmm/features/volatility_ratio.py
@@ -1,0 +1,136 @@
+"""Volatility-ratio side-information predictor (Christensen et al. §4.2).
+
+The paper's Predictor I is the ratio of a short-window EWMA volatility estimate
+to a long-window EWMA volatility estimate. Both estimators use the J.P. Morgan
+RiskMetrics IGARCH(1,1) formulation of Eq. (4):
+
+    σ_{t+1|t} = sqrt( (1 - λ) · Σ_{τ=0}^{ψ} λ^τ · Δy²_{t-τ} )
+
+with decay ``λ = 0.79`` for 1-minute data and window sizes ``ψ_fast = 50`` and
+``ψ_slow = 100``. The predictor is ``X_t = σ_{t+1|t}(ψ_fast) / σ_{t+1|t}(ψ_slow)``.
+
+This module is paper-faithful: the finite-sum EWMA form and the default
+parameter values follow the paper directly. Downstream consumers (spline
+predictor, IOHMM bucketing) treat the output ``pd.Series`` as their input ``x_t``.
+
+References: §4.2 volatility ratio
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+import numpy as np
+import pandas as pd
+from numpy.lib.stride_tricks import sliding_window_view
+
+from hft_hmm.core.references import PAPER_FAITHFUL, PaperReference, reference
+
+__category__: Final[str] = PAPER_FAITHFUL
+VOLATILITY_RATIO_REFERENCE: Final[PaperReference] = reference("§4.2", "volatility ratio")
+
+DEFAULT_DECAY: Final[float] = 0.79
+DEFAULT_FAST_WINDOW: Final[int] = 50
+DEFAULT_SLOW_WINDOW: Final[int] = 100
+
+
+@dataclass(frozen=True)
+class VolatilityRatioConfig:
+    """Typed parameter bundle for the volatility-ratio predictor.
+
+    ``decay`` is the EWMA variance decay λ shared by both estimators.
+    ``fast_window`` and ``slow_window`` are the paper's ψ_fast and ψ_slow, i.e.
+    the number of historical observations retained in each truncated sum.
+
+    References: §4.2 volatility ratio
+    """
+
+    decay: float = DEFAULT_DECAY
+    fast_window: int = DEFAULT_FAST_WINDOW
+    slow_window: int = DEFAULT_SLOW_WINDOW
+
+    def __post_init__(self) -> None:
+        _validate_decay(self.decay)
+        _validate_window(self.fast_window, name="fast_window")
+        _validate_window(self.slow_window, name="slow_window")
+        if self.fast_window >= self.slow_window:
+            raise ValueError(
+                "fast_window must be strictly less than slow_window; "
+                f"got fast_window={self.fast_window}, slow_window={self.slow_window}."
+            )
+
+
+def ewma_volatility(
+    returns: pd.Series,
+    *,
+    decay: float,
+    window: int,
+) -> pd.Series:
+    """Compute the paper's truncated EWMA volatility forecast σ_{t+1|t}.
+
+    At index ``t`` the output is ``sqrt((1 - decay) · Σ_{τ=0}^{window} decay^τ ·
+    returns²_{t-τ})``. The first ``window`` positions are NaN because the
+    truncated sum requires ``window + 1`` observations. The input ``returns``
+    must be numeric and free of NaN; callers should ``.dropna()`` log returns
+    before calling this function.
+
+    References: §4.2, Eq. (4)
+    """
+    _validate_decay(decay)
+    _validate_window(window, name="window")
+    if not isinstance(returns, pd.Series):
+        raise TypeError(f"returns must be a pandas Series, got {type(returns).__name__}.")
+
+    values = returns.to_numpy(dtype=float)
+    if np.isnan(values).any():
+        raise ValueError("returns must not contain NaN; drop missing values before calling.")
+
+    squared = values**2
+    sigma = np.full(values.shape[0], np.nan, dtype=float)
+    if values.shape[0] >= window + 1:
+        weights = decay ** np.arange(window + 1, dtype=float)
+        reversed_weights = weights[::-1]
+        windows = sliding_window_view(squared, window + 1)
+        variance_tail = (1.0 - decay) * (windows @ reversed_weights)
+        sigma[window:] = np.sqrt(variance_tail)
+
+    return pd.Series(sigma, index=returns.index, name=returns.name)
+
+
+def volatility_ratio(
+    returns: pd.Series,
+    *,
+    fast_window: int = DEFAULT_FAST_WINDOW,
+    slow_window: int = DEFAULT_SLOW_WINDOW,
+    decay: float = DEFAULT_DECAY,
+) -> pd.Series:
+    """Compute the paper's volatility-ratio predictor σ_fast / σ_slow.
+
+    Both estimators share ``decay`` and differ only in the truncation window.
+    The first ``slow_window`` positions are NaN. The output is a pandas Series
+    aligned with the input index.
+
+    References: §4.2 volatility ratio
+    """
+    config = VolatilityRatioConfig(
+        decay=decay,
+        fast_window=fast_window,
+        slow_window=slow_window,
+    )
+    sigma_fast = ewma_volatility(returns, decay=config.decay, window=config.fast_window)
+    sigma_slow = ewma_volatility(returns, decay=config.decay, window=config.slow_window)
+    ratio = sigma_fast / sigma_slow
+    return ratio.rename(returns.name)
+
+
+def _validate_decay(decay: float) -> None:
+    if not np.isfinite(decay) or not (0.0 < decay < 1.0):
+        raise ValueError(f"decay must be a finite value in (0, 1); got {decay!r}.")
+
+
+def _validate_window(window: int, *, name: str) -> None:
+    if not isinstance(window, (int, np.integer)) or isinstance(window, bool):
+        raise TypeError(f"{name} must be an integer; got {type(window).__name__}.")
+    if window < 1:
+        raise ValueError(f"{name} must be a positive integer; got {window}.")

--- a/src/hft_hmm/features/volatility_ratio.py
+++ b/src/hft_hmm/features/volatility_ratio.py
@@ -84,9 +84,7 @@ def ewma_volatility(
 
     values = returns.to_numpy(dtype=float)
     if not np.isfinite(values).all():
-        raise ValueError(
-            "returns must be finite; drop or mask non-finite values before calling."
-        )
+        raise ValueError("returns must be finite; drop or mask non-finite values before calling.")
 
     squared = values**2
     sigma = np.full(values.shape[0], np.nan, dtype=float)

--- a/tests/test_volatility_ratio.py
+++ b/tests/test_volatility_ratio.py
@@ -95,9 +95,10 @@ def test_ewma_volatility_returns_all_nan_when_input_shorter_than_window() -> Non
     assert len(sigma) == len(returns)
 
 
-def test_ewma_volatility_rejects_nan_input() -> None:
-    returns = _series(np.array([0.001, np.nan, 0.002, 0.0]))
-    with pytest.raises(ValueError, match="NaN"):
+@pytest.mark.parametrize("bad_value", [np.nan, np.inf, -np.inf])
+def test_ewma_volatility_rejects_non_finite_input(bad_value: float) -> None:
+    returns = _series(np.array([0.001, bad_value, 0.002, 0.0]))
+    with pytest.raises(ValueError, match="finite"):
         ewma_volatility(returns, decay=0.5, window=2)
 
 

--- a/tests/test_volatility_ratio.py
+++ b/tests/test_volatility_ratio.py
@@ -1,0 +1,210 @@
+"""Tests for the volatility-ratio side-information predictor."""
+
+from __future__ import annotations
+
+import importlib
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from hft_hmm.core.references import PAPER_FAITHFUL, module_category
+from hft_hmm.features.volatility_ratio import (
+    DEFAULT_DECAY,
+    DEFAULT_FAST_WINDOW,
+    DEFAULT_SLOW_WINDOW,
+    VOLATILITY_RATIO_REFERENCE,
+    VolatilityRatioConfig,
+    ewma_volatility,
+    volatility_ratio,
+)
+
+vr_module = importlib.import_module("hft_hmm.features.volatility_ratio")
+
+
+def _index(n: int) -> pd.DatetimeIndex:
+    return pd.date_range("2024-01-02 09:30", periods=n, freq="1min", tz="UTC")
+
+
+def _series(values: np.ndarray) -> pd.Series:
+    return pd.Series(values, index=_index(values.shape[0]), name="ret")
+
+
+# --- module taxonomy / reference wiring ---
+
+
+def test_module_is_paper_faithful() -> None:
+    assert module_category(vr_module) == PAPER_FAITHFUL
+
+
+def test_paper_reference_points_to_section_4_2() -> None:
+    assert VOLATILITY_RATIO_REFERENCE.section == "§4.2"
+    assert "volatility" in VOLATILITY_RATIO_REFERENCE.topic.lower()
+
+
+# --- ewma_volatility ---
+
+
+def test_ewma_volatility_matches_closed_form_on_constant_returns() -> None:
+    # Δy² ≡ c ⇒ σ² = (1 - λ) · c · Σ_{τ=0}^{ψ} λ^τ = c · (1 - λ^{ψ+1}).
+    decay = 0.79
+    window = 50
+    c = 0.0004  # squared return magnitude
+    returns = _series(np.full(window + 5, np.sqrt(c)))
+
+    sigma = ewma_volatility(returns, decay=decay, window=window)
+
+    assert sigma.iloc[:window].isna().all()
+    expected_variance = c * (1.0 - decay ** (window + 1))
+    np.testing.assert_allclose(
+        sigma.iloc[window:].to_numpy(),
+        np.sqrt(expected_variance),
+        rtol=1e-12,
+    )
+
+
+def test_ewma_volatility_matches_brute_force_on_random_returns() -> None:
+    rng = np.random.default_rng(42)
+    decay = 0.79
+    window = 10
+    values = rng.normal(scale=1e-3, size=window + 25)
+    returns = _series(values)
+
+    sigma = ewma_volatility(returns, decay=decay, window=window)
+
+    weights = decay ** np.arange(window + 1)
+    expected = np.full(values.shape[0], np.nan)
+    for t in range(window, values.shape[0]):
+        tau_squared = values[t - window : t + 1][::-1] ** 2
+        expected[t] = np.sqrt((1.0 - decay) * np.dot(weights, tau_squared))
+
+    np.testing.assert_allclose(sigma.to_numpy(), expected, rtol=1e-12, equal_nan=True)
+
+
+def test_ewma_volatility_preserves_index_and_name() -> None:
+    returns = _series(np.linspace(-1e-3, 1e-3, 20))
+    sigma = ewma_volatility(returns, decay=0.5, window=5)
+    pd.testing.assert_index_equal(sigma.index, returns.index)
+    assert sigma.name == returns.name
+
+
+def test_ewma_volatility_returns_all_nan_when_input_shorter_than_window() -> None:
+    returns = _series(np.array([0.001, -0.001]))
+    sigma = ewma_volatility(returns, decay=0.5, window=10)
+    assert sigma.isna().all()
+    assert len(sigma) == len(returns)
+
+
+def test_ewma_volatility_rejects_nan_input() -> None:
+    returns = _series(np.array([0.001, np.nan, 0.002, 0.0]))
+    with pytest.raises(ValueError, match="NaN"):
+        ewma_volatility(returns, decay=0.5, window=2)
+
+
+def test_ewma_volatility_rejects_non_series_input() -> None:
+    with pytest.raises(TypeError, match="Series"):
+        ewma_volatility(np.array([0.001, 0.002, 0.003]), decay=0.5, window=1)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("bad_decay", [-0.1, 0.0, 1.0, 1.5, float("nan"), float("inf")])
+def test_ewma_volatility_rejects_invalid_decay(bad_decay: float) -> None:
+    returns = _series(np.array([0.001, 0.002, 0.003]))
+    with pytest.raises(ValueError, match="decay"):
+        ewma_volatility(returns, decay=bad_decay, window=1)
+
+
+@pytest.mark.parametrize("bad_window", [0, -1, -10])
+def test_ewma_volatility_rejects_non_positive_window(bad_window: int) -> None:
+    returns = _series(np.array([0.001, 0.002, 0.003]))
+    with pytest.raises(ValueError, match="window"):
+        ewma_volatility(returns, decay=0.5, window=bad_window)
+
+
+def test_ewma_volatility_rejects_non_integer_window() -> None:
+    returns = _series(np.array([0.001, 0.002, 0.003]))
+    with pytest.raises(TypeError, match="integer"):
+        ewma_volatility(returns, decay=0.5, window=1.5)  # type: ignore[arg-type]
+
+
+# --- volatility_ratio ---
+
+
+def test_volatility_ratio_uses_paper_defaults() -> None:
+    assert DEFAULT_DECAY == 0.79
+    assert DEFAULT_FAST_WINDOW == 50
+    assert DEFAULT_SLOW_WINDOW == 100
+
+
+def test_volatility_ratio_matches_closed_form_on_constant_squared_returns() -> None:
+    # Constant Δy² = c gives σ² = c · (1 - λ^{ψ+1}), so the ratio is
+    # sqrt((1 - λ^{ψf+1}) / (1 - λ^{ψs+1})) — a fixed value independent of c.
+    returns = _series(np.full(200, 0.01))
+    ratio = volatility_ratio(returns)
+    valid = ratio.dropna()
+    assert len(valid) == 200 - DEFAULT_SLOW_WINDOW
+
+    expected = np.sqrt(
+        (1.0 - DEFAULT_DECAY ** (DEFAULT_FAST_WINDOW + 1))
+        / (1.0 - DEFAULT_DECAY ** (DEFAULT_SLOW_WINDOW + 1))
+    )
+    np.testing.assert_allclose(valid.to_numpy(), expected, rtol=1e-12)
+
+
+def test_volatility_ratio_drops_below_one_after_high_to_low_shift() -> None:
+    # Use a near-unit decay so ψ actually controls effective memory and the
+    # slow window can still "see" the high-vol prefix when the fast window no
+    # longer does. With the paper's default λ = 0.79 the effective memory is
+    # roughly 1/(1 - λ) ≈ 5 observations, so ψ_fast = 50 vs ψ_slow = 100 make
+    # indistinguishable estimates once both truncated sums have converged.
+    rng = np.random.default_rng(7)
+    high_vol = rng.normal(scale=1e-2, size=200)
+    low_vol = rng.normal(scale=1e-4, size=200)
+    returns = _series(np.concatenate([high_vol, low_vol]))
+
+    ratio = volatility_ratio(returns, fast_window=30, slow_window=150, decay=0.99)
+
+    # Well after the shift the fast window sits entirely inside the low-vol
+    # regime while the slow window still retains high-vol history.
+    at_shift_plus_fast = ratio.iloc[200 + 40]
+    assert at_shift_plus_fast < 0.5
+
+
+def test_volatility_ratio_aligns_and_masks_slow_window_prefix() -> None:
+    returns = _series(np.linspace(-1e-3, 1e-3, DEFAULT_SLOW_WINDOW + 20))
+    ratio = volatility_ratio(returns)
+
+    pd.testing.assert_index_equal(ratio.index, returns.index)
+    assert ratio.iloc[:DEFAULT_SLOW_WINDOW].isna().all()
+    assert ratio.iloc[DEFAULT_SLOW_WINDOW:].notna().all()
+
+
+def test_volatility_ratio_is_deterministic() -> None:
+    rng = np.random.default_rng(123)
+    returns = _series(rng.normal(scale=1e-3, size=300))
+    first = volatility_ratio(returns)
+    second = volatility_ratio(returns)
+    pd.testing.assert_series_equal(first, second)
+
+
+def test_volatility_ratio_rejects_fast_ge_slow() -> None:
+    returns = _series(np.array([0.001, 0.002, 0.003, 0.004]))
+    with pytest.raises(ValueError, match="fast_window"):
+        volatility_ratio(returns, fast_window=5, slow_window=5)
+    with pytest.raises(ValueError, match="fast_window"):
+        volatility_ratio(returns, fast_window=10, slow_window=5)
+
+
+def test_volatility_ratio_config_validates_on_construction() -> None:
+    with pytest.raises(ValueError, match="decay"):
+        VolatilityRatioConfig(decay=1.5)
+    with pytest.raises(ValueError, match="fast_window"):
+        VolatilityRatioConfig(fast_window=100, slow_window=50)
+    with pytest.raises(ValueError, match="slow_window"):
+        VolatilityRatioConfig(slow_window=0)
+
+
+def test_volatility_ratio_config_exposes_paper_defaults() -> None:
+    config = VolatilityRatioConfig()
+    assert config.decay == DEFAULT_DECAY
+    assert config.fast_window == DEFAULT_FAST_WINDOW
+    assert config.slow_window == DEFAULT_SLOW_WINDOW


### PR DESCRIPTION
Closes #30.

## Summary

- Adds `src/hft_hmm/features/volatility_ratio.py` (paper-faithful, §4.2) implementing the truncated EWMA variance of Eq. (4) and the σ_fast / σ_slow ratio predictor with the paper's defaults (λ = 0.79, ψ_fast = 50, ψ_slow = 100).
- Exposes a typed `VolatilityRatioConfig` dataclass with field validation so downstream Issue 15 (spline predictor), Issue 16 (IOHMM bucketing), and Issue 22 (standalone backtest) can bind predictor parameters without redefining defaults.
- Wires `ewma_volatility`, `volatility_ratio`, `VolatilityRatioConfig`, and `VOLATILITY_RATIO_REFERENCE` through the `hft_hmm` top-level package.
- Adds 26 tests in `tests/test_volatility_ratio.py` covering closed-form EWMA values on constant inputs, a brute-force reference check on random returns, index/name preservation, short-input handling, NaN rejection, decay/window validation, regime-shift detection on a high-decay configuration, determinism, and config-level invariants.

## Paper-faithful note

Both estimators share λ and differ only in the truncation window ψ, matching §4.2 literally. Under the paper's default λ = 0.79 the effective memory is roughly 1/(1−λ) ≈ 5 observations, so ψ_fast = 50 vs ψ_slow = 100 produce near-identical estimates once both sums converge. The regime-shift test therefore uses a higher decay (λ = 0.99) to exercise the window-length lever; the constant-input test asserts the exact closed-form ratio at the paper's defaults.

## Test plan

- [x] `pytest --no-cov -q` — 341 tests pass
- [x] `ruff check src/hft_hmm tests/` clean
- [x] `black --check src/hft_hmm tests/` clean
- [x] New module hits 100% line coverage
- [ ] Consumed by Issue 15 (spline predictor) — next PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Volatility ratio predictor now available in public API for computing fast/slow volatility dynamics
  * EWMA (Exponential Weighted Moving Average) volatility calculations with configurable parameters
  * Pre-configured default values for immediate use

* **Tests**
  * Comprehensive test coverage for volatility calculations, parameter validation, and edge case handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->