### PR TITLE
Issue 22 - Standalone predictor backtests

### DIFF
--- a/configs/example_es_seasonality_standalone.yaml
+++ b/configs/example_es_seasonality_standalone.yaml
@@ -1,0 +1,31 @@
+cost_bps_per_turnover: 1.0
+data:
+  end: null
+  kind: csv
+  path: tests/fixtures/es_1min_month.csv
+  start: null
+  symbol: null
+frequency: 1min
+notes: Standalone intraday-seasonality predictor backtest on January 2024 ES CSV
+  fixture. Signal is sign(f(x_t)) from a cubic spline fitted on the training window
+  only. No HMM state. Paper section 4 baseline before IOHMM conditioning.
+predictor: seasonality
+seasonality:
+  bucket_minutes: 1
+  exchange_tz: America/Chicago
+  normalize: true
+sha256: c81161b1932361e119483a37fa27b2e16ce39020bcfcc3e871812c5cb7a9ca34
+spline:
+  degree: 3
+  demean: false
+  demean_grid_size: 1000
+  min_obs: 20
+  n_knots: 5
+vol_ratio:
+  decay: 0.79
+  fast_window: 50
+  slow_window: 100
+walk_forward:
+  h_days: 10
+  retrain_every_days: 2
+  t_days: 2

--- a/configs/example_es_vol_ratio_standalone.yaml
+++ b/configs/example_es_vol_ratio_standalone.yaml
@@ -1,0 +1,31 @@
+cost_bps_per_turnover: 1.0
+data:
+  end: null
+  kind: csv
+  path: tests/fixtures/es_1min_month.csv
+  start: null
+  symbol: null
+frequency: 1min
+notes: Standalone volatility-ratio predictor backtest on January 2024 ES CSV fixture.
+  Signal is sign(f(x_t)) from a cubic spline fitted on the training window only.
+  No HMM state. Paper section 4 baseline before IOHMM conditioning.
+predictor: volatility_ratio
+seasonality:
+  bucket_minutes: 1
+  exchange_tz: America/Chicago
+  normalize: true
+sha256: c81161b1932361e119483a37fa27b2e16ce39020bcfcc3e871812c5cb7a9ca34
+spline:
+  degree: 3
+  demean: false
+  demean_grid_size: 1000
+  min_obs: 20
+  n_knots: 5
+vol_ratio:
+  decay: 0.79
+  fast_window: 50
+  slow_window: 100
+walk_forward:
+  h_days: 10
+  retrain_every_days: 2
+  t_days: 2

--- a/scripts/repro.py
+++ b/scripts/repro.py
@@ -11,8 +11,14 @@ import argparse
 import sys
 from pathlib import Path
 
+import yaml
+
 from hft_hmm.config import ExperimentConfig
 from hft_hmm.experiments.runner import run_experiment
+from hft_hmm.experiments.standalone_predictor import (
+    StandaloneExperimentConfig,
+    run_standalone_experiment,
+)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -37,8 +43,22 @@ def main(argv: list[str] | None = None) -> int:
         print(f"Config not found: {args.config}", file=sys.stderr)
         return 2
 
-    config = ExperimentConfig.from_yaml(args.config)
-    artifacts = run_experiment(config, runs_root=args.runs_root, force=args.force)
+    raw = yaml.safe_load(args.config.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        print(
+            f"Config must decode to a YAML mapping, got {type(raw).__name__}.",
+            file=sys.stderr,
+        )
+        return 2
+
+    if "predictor" in raw:
+        standalone_config = StandaloneExperimentConfig.from_dict(raw)
+        artifacts = run_standalone_experiment(
+            standalone_config, runs_root=args.runs_root, force=args.force
+        )
+    else:
+        config = ExperimentConfig.from_dict(raw)
+        artifacts = run_experiment(config, runs_root=args.runs_root, force=args.force)
     print(str(artifacts.directory))
     return 0
 

--- a/scripts/repro.py
+++ b/scripts/repro.py
@@ -1,5 +1,10 @@
 """Run an experiment YAML end-to-end and write artifacts to ``runs/<run_id>/``.
 
+Config dispatch is schema-based: a top-level ``predictor`` key selects the
+standalone predictor runner. In that mode, HMM-only ``walk_forward`` fields are
+not consumed: ``min_variance``, ``variance_floor_policy``, ``k_values``,
+``n_iter``, and ``tol``.
+
 Usage:
     python scripts/repro.py configs/example_es_csv.yaml
     python scripts/repro.py my_config.yaml --force --runs-root custom_runs
@@ -9,7 +14,9 @@ from __future__ import annotations
 
 import argparse
 import sys
+import warnings
 from pathlib import Path
+from typing import Final
 
 import yaml
 
@@ -18,6 +25,10 @@ from hft_hmm.experiments.runner import run_experiment
 from hft_hmm.experiments.standalone_predictor import (
     StandaloneExperimentConfig,
     run_standalone_experiment,
+)
+
+_HMM_ONLY_WALK_FORWARD_KEYS: Final[frozenset[str]] = frozenset(
+    {"min_variance", "variance_floor_policy", "k_values", "n_iter", "tol"}
 )
 
 
@@ -52,6 +63,7 @@ def main(argv: list[str] | None = None) -> int:
         return 2
 
     if "predictor" in raw:
+        _warn_on_ignored_hmm_keys(raw)
         standalone_config = StandaloneExperimentConfig.from_dict(raw)
         artifacts = run_standalone_experiment(
             standalone_config, runs_root=args.runs_root, force=args.force
@@ -61,6 +73,24 @@ def main(argv: list[str] | None = None) -> int:
         artifacts = run_experiment(config, runs_root=args.runs_root, force=args.force)
     print(str(artifacts.directory))
     return 0
+
+
+def _warn_on_ignored_hmm_keys(raw: dict[str, object]) -> None:
+    walk_forward = raw.get("walk_forward")
+    if not isinstance(walk_forward, dict):
+        return
+
+    ignored = sorted(_HMM_ONLY_WALK_FORWARD_KEYS.intersection(walk_forward))
+    if not ignored:
+        return
+
+    warnings.warn(
+        "Config contains top-level 'predictor', so scripts/repro.py will run "
+        "the standalone predictor schema. HMM-only walk_forward fields will "
+        f"be ignored: {', '.join(ignored)}.",
+        UserWarning,
+        stacklevel=2,
+    )
 
 
 if __name__ == "__main__":

--- a/src/hft_hmm/__init__.py
+++ b/src/hft_hmm/__init__.py
@@ -46,6 +46,18 @@ from hft_hmm.experiments import (
     walk_forward,
 )
 from hft_hmm.experiments.runner import NON_REPRODUCIBLE_WARNING, RunArtifacts, run_experiment
+from hft_hmm.experiments.standalone_predictor import (
+    STANDALONE_PREDICTOR_REFERENCE,
+    StandaloneExperimentConfig,
+    StandalonePredictorConfig,
+    StandalonePredictorResult,
+    StandalonePredictorWindow,
+    StandaloneRunArtifacts,
+    StandaloneWalkForwardConfig,
+    run_standalone_experiment,
+    standalone_predictor_backtest,
+    standalone_run_id,
+)
 from hft_hmm.features import (
     DEFAULT_BUCKET_MINUTES,
     DEFAULT_EXCHANGE_TZ,
@@ -95,6 +107,13 @@ __all__ = [
     "EXPERIMENT_CONFIG_REFERENCE",
     "INTRADAY_SEASONALITY_REFERENCE",
     "NON_REPRODUCIBLE_WARNING",
+    "STANDALONE_PREDICTOR_REFERENCE",
+    "StandaloneExperimentConfig",
+    "StandalonePredictorConfig",
+    "StandalonePredictorResult",
+    "StandalonePredictorWindow",
+    "StandaloneRunArtifacts",
+    "StandaloneWalkForwardConfig",
     "PAPER_FAITHFUL",
     "PROJECT_NAME",
     "SIGNAL_REFERENCE",
@@ -149,6 +168,9 @@ __all__ = [
     "resample_prices",
     "run_experiment",
     "run_id",
+    "run_standalone_experiment",
+    "standalone_predictor_backtest",
+    "standalone_run_id",
     "sharpe_ratio",
     "sign_signal",
     "signal_turnover",

--- a/src/hft_hmm/experiments/_data_loading.py
+++ b/src/hft_hmm/experiments/_data_loading.py
@@ -1,0 +1,111 @@
+"""Shared data loading and reproducibility helpers for experiment runners.
+
+Both baseline HMM experiments and standalone predictor experiments load market
+data through the same source contract, resampling, and return preprocessing.
+Keeping that path here prevents drift between comparable experiment runners.
+
+References: §4.4 reproducible simulation artifacts (evaluation layer)
+"""
+
+from __future__ import annotations
+
+import warnings
+from typing import Final, Protocol
+
+import pandas as pd
+
+from hft_hmm.config.experiment_config import DataSourceConfig, compute_file_sha256
+from hft_hmm.data import (
+    load_csv_market_data,
+    load_databento_parquet,
+    load_yfinance_market_data,
+)
+from hft_hmm.preprocessing import compute_log_returns, resample_prices
+
+NON_REPRODUCIBLE_WARNING: Final[str] = (
+    "yfinance data may drift across vendor updates; re-runs may not match bit-for-bit."
+)
+DATA_FINGERPRINT_MISMATCH_WARNING: Final[str] = (
+    "Configured sha256 does not match file contents at {path}; "
+    "the run will be marked non-reproducible."
+)
+
+_YFINANCE_INTERVAL: Final[dict[str, str]] = {
+    "1min": "1m",
+    "5min": "5m",
+    "1D": "1d",
+}
+
+
+class ReproducibleExperimentConfig(Protocol):
+    """Minimal config protocol needed for reproducibility validation."""
+
+    @property
+    def data(self) -> DataSourceConfig: ...
+
+    @property
+    def sha256(self) -> str | None: ...
+
+    @property
+    def is_reproducible(self) -> bool: ...
+
+
+def load_returns_from_source(data: DataSourceConfig, *, frequency: str) -> pd.Series:
+    """Load raw market data, resample, and return tz-aware log returns.
+
+    ``data.kind`` selects the source loader; all paths then route through the
+    same resampling and log-return preprocessing. The output name is always
+    ``"log_return"``.
+
+    References: §4.4 reproducible simulation artifacts (evaluation layer)
+    """
+    if frequency not in _YFINANCE_INTERVAL:
+        raise ValueError(
+            f"frequency must be one of {tuple(_YFINANCE_INTERVAL)}, got {frequency!r}."
+        )
+
+    if data.kind == "csv":
+        assert data.path is not None  # validated in DataSourceConfig.__post_init__
+        frame = load_csv_market_data(data.path)
+    elif data.kind == "databento_parquet":
+        assert data.path is not None
+        assert data.symbol is not None
+        frame = load_databento_parquet(data.path, symbol=data.symbol)
+    else:
+        assert data.symbol is not None
+        assert data.start is not None and data.end is not None
+        frame = load_yfinance_market_data(
+            data.symbol,
+            start=data.start,
+            end=data.end,
+            interval=_YFINANCE_INTERVAL[frequency],
+        )
+
+    resampled = resample_prices(frame, freq=frequency)
+    prices = resampled.set_index("timestamp")["price"]
+    returns = compute_log_returns(prices).dropna()
+    returns.name = "log_return"
+    return returns
+
+
+def validate_data_reproducibility(
+    config: ReproducibleExperimentConfig,
+    *,
+    stacklevel: int = 2,
+) -> bool:
+    """Return whether a config is reproducible, emitting standard warnings."""
+    if not config.is_reproducible:
+        warnings.warn(NON_REPRODUCIBLE_WARNING, UserWarning, stacklevel=stacklevel)
+        return False
+
+    assert config.data.path is not None
+    assert config.sha256 is not None
+    actual_sha256 = compute_file_sha256(config.data.path)
+    if actual_sha256 != config.sha256:
+        warnings.warn(
+            DATA_FINGERPRINT_MISMATCH_WARNING.format(path=config.data.path),
+            UserWarning,
+            stacklevel=stacklevel,
+        )
+        return False
+    return True

--- a/src/hft_hmm/experiments/runner.py
+++ b/src/hft_hmm/experiments/runner.py
@@ -18,38 +18,23 @@ import os
 import shutil
 import tempfile
 import uuid
-import warnings
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Final
 
 import pandas as pd
 
-from hft_hmm.config.experiment_config import ExperimentConfig, compute_file_sha256, run_id
+from hft_hmm.config.experiment_config import ExperimentConfig, run_id
 from hft_hmm.core import EVALUATION_LAYER
-from hft_hmm.data import (
-    load_csv_market_data,
-    load_databento_parquet,
-    load_yfinance_market_data,
+from hft_hmm.experiments._data_loading import (
+    DATA_FINGERPRINT_MISMATCH_WARNING,  # noqa: F401 -- re-exported compatibility constant
+    NON_REPRODUCIBLE_WARNING,  # noqa: F401 -- re-exported compatibility constant
+    load_returns_from_source,
+    validate_data_reproducibility,
 )
 from hft_hmm.experiments.walk_forward import WalkForwardResult, walk_forward
-from hft_hmm.preprocessing import compute_log_returns, resample_prices
 
 __category__: Final[str] = EVALUATION_LAYER
-
-NON_REPRODUCIBLE_WARNING: Final[str] = (
-    "yfinance data may drift across vendor updates; re-runs may not match bit-for-bit."
-)
-DATA_FINGERPRINT_MISMATCH_WARNING: Final[str] = (
-    "Configured sha256 does not match file contents at {path}; "
-    "the run will be marked non-reproducible."
-)
-
-_YFINANCE_INTERVAL: Final[dict[str, str]] = {
-    "1min": "1m",
-    "5min": "5m",
-    "1D": "1d",
-}
 
 
 @dataclass(frozen=True)
@@ -129,46 +114,11 @@ def run_experiment(
 
 def _load_returns(config: ExperimentConfig) -> pd.Series:
     """Load raw market data, resample, and return tz-aware log returns."""
-    if config.data.kind == "csv":
-        assert config.data.path is not None  # validated in DataSourceConfig.__post_init__
-        frame = load_csv_market_data(config.data.path)
-    elif config.data.kind == "databento_parquet":
-        assert config.data.path is not None
-        assert config.data.symbol is not None
-        frame = load_databento_parquet(config.data.path, symbol=config.data.symbol)
-    else:  # yfinance
-        assert config.data.symbol is not None
-        assert config.data.start is not None and config.data.end is not None
-        frame = load_yfinance_market_data(
-            config.data.symbol,
-            start=config.data.start,
-            end=config.data.end,
-            interval=_YFINANCE_INTERVAL[config.frequency],
-        )
-
-    resampled = resample_prices(frame, freq=config.frequency)
-    prices = resampled.set_index("timestamp")["price"]
-    returns = compute_log_returns(prices).dropna()
-    returns.name = "log_return"
-    return returns
+    return load_returns_from_source(config.data, frequency=config.frequency)
 
 
 def _validate_reproducibility(config: ExperimentConfig) -> bool:
-    if not config.is_reproducible:
-        warnings.warn(NON_REPRODUCIBLE_WARNING, UserWarning, stacklevel=2)
-        return False
-
-    assert config.data.path is not None
-    assert config.sha256 is not None
-    actual_sha256 = compute_file_sha256(config.data.path)
-    if actual_sha256 != config.sha256:
-        warnings.warn(
-            DATA_FINGERPRINT_MISMATCH_WARNING.format(path=config.data.path),
-            UserWarning,
-            stacklevel=2,
-        )
-        return False
-    return True
+    return validate_data_reproducibility(config, stacklevel=3)
 
 
 def _write_artifacts(

--- a/src/hft_hmm/experiments/standalone_predictor.py
+++ b/src/hft_hmm/experiments/standalone_predictor.py
@@ -127,6 +127,20 @@ class StandalonePredictorConfig:
                 f"walk_forward must be a StandaloneWalkForwardConfig, "
                 f"got {type(self.walk_forward).__name__}."
             )
+        if not isinstance(self.spline, SplinePredictorConfig):
+            raise TypeError(
+                f"spline must be a SplinePredictorConfig, got {type(self.spline).__name__}."
+            )
+        if not isinstance(self.vol_ratio, VolatilityRatioConfig):
+            raise TypeError(
+                "vol_ratio must be a VolatilityRatioConfig, "
+                f"got {type(self.vol_ratio).__name__}."
+            )
+        if not isinstance(self.seasonality, SeasonalityConfig):
+            raise TypeError(
+                "seasonality must be a SeasonalityConfig, "
+                f"got {type(self.seasonality).__name__}."
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -250,6 +264,15 @@ def standalone_predictor_backtest(
 
     References: §4 side-information predictor standalone evaluation (evaluation layer)
     """
+    if not isinstance(config, StandalonePredictorConfig):
+        raise TypeError(
+            f"config must be a StandalonePredictorConfig, got {type(config).__name__}."
+        )
+    if not np.isfinite(cost_bps_per_turnover) or cost_bps_per_turnover < 0.0:
+        raise ValueError(
+            "cost_bps_per_turnover must be a finite non-negative float, "
+            f"got {cost_bps_per_turnover!r}."
+        )
     _validate_returns(returns)
 
     sorted_dates = np.array(sorted(set(returns.index.date)), dtype=object)
@@ -418,6 +441,20 @@ class StandaloneExperimentConfig:
             raise TypeError(
                 "walk_forward must be a StandaloneWalkForwardConfig, "
                 f"got {type(self.walk_forward).__name__}."
+            )
+        if not isinstance(self.spline, SplinePredictorConfig):
+            raise TypeError(
+                f"spline must be a SplinePredictorConfig, got {type(self.spline).__name__}."
+            )
+        if not isinstance(self.vol_ratio, VolatilityRatioConfig):
+            raise TypeError(
+                "vol_ratio must be a VolatilityRatioConfig, "
+                f"got {type(self.vol_ratio).__name__}."
+            )
+        if not isinstance(self.seasonality, SeasonalityConfig):
+            raise TypeError(
+                "seasonality must be a SeasonalityConfig, "
+                f"got {type(self.seasonality).__name__}."
             )
         cost = float(self.cost_bps_per_turnover)
         if not math.isfinite(cost) or cost < 0.0:

--- a/src/hft_hmm/experiments/standalone_predictor.py
+++ b/src/hft_hmm/experiments/standalone_predictor.py
@@ -23,7 +23,6 @@ import os
 import shutil
 import tempfile
 import uuid
-import warnings
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Final, Literal
@@ -35,7 +34,6 @@ import yaml
 from hft_hmm.config.experiment_config import (
     DataSourceConfig,
     Frequency,
-    compute_file_sha256,
 )
 from hft_hmm.core import EVALUATION_LAYER, PaperReference, reference
 from hft_hmm.evaluation import (
@@ -45,6 +43,10 @@ from hft_hmm.evaluation import (
     max_drawdown,
     sharpe_ratio,
     signal_turnover,
+)
+from hft_hmm.experiments._data_loading import (
+    load_returns_from_source,
+    validate_data_reproducibility,
 )
 from hft_hmm.features.seasonality import SeasonalityConfig, intraday_seasonality
 from hft_hmm.features.splines import SplinePredictorConfig, fit_spline_predictor
@@ -60,14 +62,6 @@ PredictorKind = Literal["volatility_ratio", "seasonality"]
 _PREDICTOR_KINDS: Final[tuple[str, ...]] = ("volatility_ratio", "seasonality")
 _VALID_FREQUENCIES: Final[tuple[str, ...]] = ("1min", "5min", "1D")
 _SHA256_HEX_LENGTH: Final[int] = 64
-_YFINANCE_INTERVAL: Final[dict[str, str]] = {"1min": "1m", "5min": "5m", "1D": "1d"}
-_NON_REPRODUCIBLE_WARNING: Final[str] = (
-    "yfinance data may drift across vendor updates; re-runs may not match bit-for-bit."
-)
-_DATA_FINGERPRINT_MISMATCH_WARNING: Final[str] = (
-    "Configured sha256 does not match file contents at {path}; "
-    "the run will be marked non-reproducible."
-)
 
 
 # ---------------------------------------------------------------------------
@@ -466,6 +460,11 @@ class StandaloneExperimentConfig:
         if self.data.is_reproducible:
             if self.sha256 is None:
                 raise ValueError("StandaloneExperimentConfig for file-backed data requires sha256.")
+            if not isinstance(self.sha256, str):
+                raise ValueError(
+                    "sha256 must be a string for file-backed standalone experiments; "
+                    f"got {type(self.sha256).__name__}."
+                )
             normalized = self.sha256.lower()
             if len(normalized) != _SHA256_HEX_LENGTH or any(
                 c not in "0123456789abcdef" for c in normalized
@@ -752,52 +751,11 @@ def _summary_row(
 
 
 def _load_returns(config: StandaloneExperimentConfig) -> pd.Series:
-    from hft_hmm.data import (
-        load_csv_market_data,
-        load_databento_parquet,
-        load_yfinance_market_data,
-    )
-    from hft_hmm.preprocessing import compute_log_returns, resample_prices
-
-    if config.data.kind == "csv":
-        assert config.data.path is not None
-        frame = load_csv_market_data(config.data.path)
-    elif config.data.kind == "databento_parquet":
-        assert config.data.path is not None
-        assert config.data.symbol is not None
-        frame = load_databento_parquet(config.data.path, symbol=config.data.symbol)
-    else:
-        assert config.data.symbol is not None
-        assert config.data.start is not None and config.data.end is not None
-        frame = load_yfinance_market_data(
-            config.data.symbol,
-            start=config.data.start,
-            end=config.data.end,
-            interval=_YFINANCE_INTERVAL[config.frequency],
-        )
-
-    resampled = resample_prices(frame, freq=config.frequency)
-    prices = resampled.set_index("timestamp")["price"]
-    returns = compute_log_returns(prices).dropna()
-    returns.name = "log_return"
-    return returns
+    return load_returns_from_source(config.data, frequency=config.frequency)
 
 
 def _validate_standalone_reproducibility(config: StandaloneExperimentConfig) -> bool:
-    if not config.is_reproducible:
-        warnings.warn(_NON_REPRODUCIBLE_WARNING, UserWarning, stacklevel=3)
-        return False
-    assert config.data.path is not None
-    assert config.sha256 is not None
-    actual = compute_file_sha256(config.data.path)
-    if actual != config.sha256:
-        warnings.warn(
-            _DATA_FINGERPRINT_MISMATCH_WARNING.format(path=config.data.path),
-            UserWarning,
-            stacklevel=3,
-        )
-        return False
-    return True
+    return validate_data_reproducibility(config, stacklevel=3)
 
 
 def _write_artifacts(

--- a/src/hft_hmm/experiments/standalone_predictor.py
+++ b/src/hft_hmm/experiments/standalone_predictor.py
@@ -1,0 +1,841 @@
+"""Standalone walk-forward backtests for spline-based side-information predictors.
+
+Evaluation layer — each predictor (volatility ratio, intraday seasonality) is
+evaluated in isolation before being folded into the IOHMM (Issue 16). The
+signal is sign(f(x_t)) where f(·) is a cubic spline fitted on the training
+window only. No HMM state is used.
+
+The walk-forward geometry, cost model, and metric definitions mirror the
+baseline HMM walk-forward (§2.3) so the results are directly comparable.
+This mirrors the paper's §4 structure: each predictor is evaluated standalone
+before being incorporated into the IOHMM.
+
+Classification: evaluation layer.
+References: §4 side-information predictors (evaluation layer)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import shutil
+import tempfile
+import uuid
+import warnings
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Final, Literal
+
+import numpy as np
+import pandas as pd
+import yaml
+
+from hft_hmm.config.experiment_config import (
+    DataSourceConfig,
+    Frequency,
+    compute_file_sha256,
+)
+from hft_hmm.core import EVALUATION_LAYER, PaperReference, reference
+from hft_hmm.evaluation import (
+    apply_turnover_cost,
+    cumulative_return,
+    hit_rate,
+    max_drawdown,
+    sharpe_ratio,
+    signal_turnover,
+)
+from hft_hmm.features.seasonality import SeasonalityConfig, intraday_seasonality
+from hft_hmm.features.splines import SplinePredictorConfig, fit_spline_predictor
+from hft_hmm.features.volatility_ratio import VolatilityRatioConfig, volatility_ratio
+from hft_hmm.strategy import align_signal_with_future_return, sign_signal
+
+__category__: Final[str] = EVALUATION_LAYER
+STANDALONE_PREDICTOR_REFERENCE: Final[PaperReference] = reference(
+    "§4", "side-information predictor standalone evaluation"
+)
+
+PredictorKind = Literal["volatility_ratio", "seasonality"]
+_PREDICTOR_KINDS: Final[tuple[str, ...]] = ("volatility_ratio", "seasonality")
+_VALID_FREQUENCIES: Final[tuple[str, ...]] = ("1min", "5min", "1D")
+_SHA256_HEX_LENGTH: Final[int] = 64
+_YFINANCE_INTERVAL: Final[dict[str, str]] = {"1min": "1m", "5min": "5m", "1D": "1d"}
+_NON_REPRODUCIBLE_WARNING: Final[str] = (
+    "yfinance data may drift across vendor updates; re-runs may not match bit-for-bit."
+)
+_DATA_FINGERPRINT_MISMATCH_WARNING: Final[str] = (
+    "Configured sha256 does not match file contents at {path}; "
+    "the run will be marked non-reproducible."
+)
+
+
+# ---------------------------------------------------------------------------
+# Config types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class StandaloneWalkForwardConfig:
+    """Walk-forward window geometry for standalone predictor backtests.
+
+    Mirrors :class:`~hft_hmm.experiments.walk_forward.WalkForwardConfig` but
+    omits all HMM-specific parameters (k_values, min_variance, etc.).
+
+    References: §2.3 rolling-window overnight retraining scheme (evaluation layer)
+    """
+
+    h_days: int = 23
+    t_days: int = 1
+    retrain_every_days: int | None = None
+
+    def __post_init__(self) -> None:
+        if self.h_days < 1:
+            raise ValueError(f"h_days must be >= 1, got {self.h_days}.")
+        if self.t_days < 1:
+            raise ValueError(f"t_days must be >= 1, got {self.t_days}.")
+        retrain = self.t_days if self.retrain_every_days is None else self.retrain_every_days
+        if retrain < 1:
+            raise ValueError(f"retrain_every_days must be >= 1, got {retrain}.")
+        object.__setattr__(self, "retrain_every_days", int(retrain))
+
+
+@dataclass(frozen=True)
+class StandalonePredictorConfig:
+    """Complete configuration for a standalone spline-predictor backtest.
+
+    ``predictor`` selects which feature to build. ``vol_ratio`` and
+    ``seasonality`` carry feature-specific parameters; the one not matching
+    ``predictor`` is ignored at runtime.
+
+    References: §4 side-information predictor standalone evaluation
+    """
+
+    predictor: PredictorKind
+    walk_forward: StandaloneWalkForwardConfig
+    spline: SplinePredictorConfig = field(default_factory=SplinePredictorConfig)
+    vol_ratio: VolatilityRatioConfig = field(default_factory=VolatilityRatioConfig)
+    seasonality: SeasonalityConfig = field(default_factory=SeasonalityConfig)
+
+    def __post_init__(self) -> None:
+        if self.predictor not in _PREDICTOR_KINDS:
+            raise ValueError(
+                f"predictor must be one of {_PREDICTOR_KINDS}, got {self.predictor!r}."
+            )
+        if not isinstance(self.walk_forward, StandaloneWalkForwardConfig):
+            raise TypeError(
+                f"walk_forward must be a StandaloneWalkForwardConfig, "
+                f"got {type(self.walk_forward).__name__}."
+            )
+
+
+# ---------------------------------------------------------------------------
+# Per-window and full-result types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class StandalonePredictorWindow:
+    """Per-window record from a standalone predictor walk-forward run.
+
+    References: §4 side-information predictor standalone evaluation
+    """
+
+    index: int
+    train_start: pd.Timestamp
+    train_end: pd.Timestamp
+    forecast_start: pd.Timestamp
+    forecast_end: pd.Timestamp
+    n_train_obs: int
+    n_forecast_obs: int
+    n_knots_effective: int
+    summary: pd.DataFrame
+
+    def __post_init__(self) -> None:
+        if self.index < 0:
+            raise ValueError(f"index must be non-negative, got {self.index}.")
+        if self.n_train_obs < 1:
+            raise ValueError(f"n_train_obs must be >= 1, got {self.n_train_obs}.")
+        if self.n_forecast_obs < 1:
+            raise ValueError(f"n_forecast_obs must be >= 1, got {self.n_forecast_obs}.")
+        if self.train_end < self.train_start:
+            raise ValueError("train_end must not precede train_start.")
+        if self.forecast_end < self.forecast_start:
+            raise ValueError("forecast_end must not precede forecast_start.")
+        if self.forecast_start <= self.train_end:
+            raise ValueError(
+                "forecast_start must be strictly after train_end; "
+                f"got train_end={self.train_end} forecast_start={self.forecast_start}."
+            )
+        if not isinstance(self.summary, pd.DataFrame):
+            raise TypeError("summary must be a pd.DataFrame.")
+
+
+@dataclass(frozen=True)
+class StandalonePredictorResult:
+    """Immutable snapshot of a standalone predictor walk-forward run.
+
+    Field layout mirrors
+    :class:`~hft_hmm.experiments.walk_forward.WalkForwardResult` so downstream
+    reporting code can handle both identically.
+
+    References: §4 side-information predictor standalone evaluation
+    """
+
+    config: StandalonePredictorConfig
+    windows: tuple[StandalonePredictorWindow, ...]
+    signal: pd.Series
+    pre_cost_returns: pd.Series
+    post_cost_returns: pd.Series
+    summary: pd.DataFrame
+    cost_bps_per_turnover: float = field(default=0.0)
+
+    def __post_init__(self) -> None:
+        if not self.windows:
+            raise ValueError("standalone predictor run produced zero windows.")
+        if not isinstance(self.signal, pd.Series):
+            raise TypeError("signal must be a pd.Series.")
+        if not isinstance(self.pre_cost_returns, pd.Series):
+            raise TypeError("pre_cost_returns must be a pd.Series.")
+        if not isinstance(self.post_cost_returns, pd.Series):
+            raise TypeError("post_cost_returns must be a pd.Series.")
+        if not isinstance(self.summary, pd.DataFrame):
+            raise TypeError("summary must be a pd.DataFrame.")
+        if self.cost_bps_per_turnover < 0.0 or not np.isfinite(self.cost_bps_per_turnover):
+            raise ValueError(
+                "cost_bps_per_turnover must be a finite non-negative float, "
+                f"got {self.cost_bps_per_turnover!r}."
+            )
+        if not np.all(np.isfinite(np.asarray(self.signal, dtype=float))):
+            raise ValueError("signal must contain only finite values.")
+        if not np.all(np.isfinite(np.asarray(self.pre_cost_returns, dtype=float))):
+            raise ValueError("pre_cost_returns must contain only finite values.")
+        if not np.all(np.isfinite(np.asarray(self.post_cost_returns, dtype=float))):
+            raise ValueError("post_cost_returns must contain only finite values.")
+        if not self.pre_cost_returns.index.equals(self.post_cost_returns.index):
+            raise ValueError("pre_cost_returns and post_cost_returns must share the same index.")
+        if len(self.pre_cost_returns) != len(self.signal) - len(self.windows):
+            raise ValueError(
+                "pre_cost_returns length must equal len(signal) - len(windows); "
+                f"got len(pre_cost_returns)={len(self.pre_cost_returns)}, "
+                f"len(signal)={len(self.signal)}, len(windows)={len(self.windows)}."
+            )
+
+
+# ---------------------------------------------------------------------------
+# Main backtest function
+# ---------------------------------------------------------------------------
+
+
+def standalone_predictor_backtest(
+    returns: pd.Series,
+    config: StandalonePredictorConfig,
+    *,
+    cost_bps_per_turnover: float = 0.0,
+) -> StandalonePredictorResult:
+    """Run a walk-forward standalone spline-predictor backtest.
+
+    For each window a spline f(x_t) ≈ E[r_{t+1} | x_t] is fitted on the
+    training slice only. The signal is sign(f(x_t)) evaluated on out-of-sample
+    feature values. No HMM state is used.
+
+    Feature computation uses the concatenated train+forecast slice for rolling
+    features (volatility ratio) so the rolling window is fully initialized at
+    the start of the forecast period. The spline is fitted on the training
+    portion only, preserving the out-of-sample boundary.
+
+    The ``returns`` series must be tz-aware UTC with a monotonic DatetimeIndex,
+    identical to the requirements of
+    :func:`~hft_hmm.experiments.walk_forward.walk_forward`.
+
+    References: §4 side-information predictor standalone evaluation (evaluation layer)
+    """
+    _validate_returns(returns)
+
+    sorted_dates = np.array(sorted(set(returns.index.date)), dtype=object)
+    n_dates = sorted_dates.size
+    wf = config.walk_forward
+    assert wf.retrain_every_days is not None  # normalized in __post_init__
+    retrain_every_days = wf.retrain_every_days
+
+    if n_dates < wf.h_days + wf.t_days:
+        raise ValueError(
+            "returns must span at least h_days + t_days distinct calendar dates; "
+            f"got {n_dates} dates for h_days={wf.h_days}, t_days={wf.t_days}."
+        )
+
+    max_window_start = n_dates - wf.h_days - wf.t_days
+    bar_dates = returns.index.date
+
+    windows: list[StandalonePredictorWindow] = []
+    signal_parts: list[pd.Series] = []
+    pre_cost_parts: list[pd.Series] = []
+    post_cost_parts: list[pd.Series] = []
+
+    for window_index, day_offset in enumerate(range(0, max_window_start + 1, retrain_every_days)):
+        train_start_date = sorted_dates[day_offset]
+        train_end_date = sorted_dates[day_offset + wf.h_days - 1]
+        forecast_start_date = sorted_dates[day_offset + wf.h_days]
+        forecast_end_date = sorted_dates[day_offset + wf.h_days + wf.t_days - 1]
+
+        train_mask = (bar_dates >= train_start_date) & (bar_dates <= train_end_date)
+        forecast_mask = (bar_dates >= forecast_start_date) & (bar_dates <= forecast_end_date)
+        train_slice = returns.loc[train_mask]
+        forecast_slice = returns.loc[forecast_mask]
+
+        # No-leakage boundary check — identical guard to walk_forward.py.
+        assert train_slice.index.max() < forecast_slice.index.min(), (
+            "standalone predictor leakage guard tripped: "
+            f"train ends at {train_slice.index.max()} but forecast starts at "
+            f"{forecast_slice.index.min()}."
+        )
+
+        next_day_offset = day_offset + retrain_every_days
+        if next_day_offset <= max_window_start:
+            next_forecast_start_date = sorted_dates[next_day_offset + wf.h_days]
+            effective_forecast = forecast_slice.loc[
+                forecast_slice.index.date < next_forecast_start_date
+            ]
+        else:
+            effective_forecast = forecast_slice
+
+        if effective_forecast.shape[0] < 2:
+            raise ValueError(
+                "each effective forecast window must contain at least 2 observations so "
+                "one-step-ahead signals can be aligned with realized returns; "
+                f"window {window_index} has {effective_forecast.shape[0]} observation(s) "
+                f"for t_days={wf.t_days} and retrain_every_days={retrain_every_days}."
+            )
+
+        # Compute feature on concat(train, forecast) so rolling features are
+        # fully initialized at the forecast boundary.
+        combined = pd.concat([train_slice, effective_forecast])
+        feature_full = _build_feature(combined, config)
+        feature_train = feature_full.loc[train_slice.index]
+        feature_forecast = feature_full.loc[effective_forecast.index]
+
+        if feature_forecast.isna().any():
+            raise ValueError(
+                f"forecast feature contains NaN in window {window_index}; "
+                "increase h_days so the rolling window is fully initialized "
+                "before the forecast slice."
+            )
+
+        # Fit spline on training data only. fit_spline_predictor drops NaN
+        # pairs internally (e.g. the vol_ratio startup region at train start).
+        spline_result = fit_spline_predictor(feature_train, train_slice, config=config.spline)
+
+        predicted = spline_result.evaluate(feature_forecast)
+        # evaluate() returns pd.Series when given a pd.Series input.
+        assert isinstance(predicted, pd.Series)
+
+        window_signal = sign_signal(predicted)
+        window_pre_cost = align_signal_with_future_return(window_signal, effective_forecast)
+        window_post_cost = apply_turnover_cost(
+            window_pre_cost,
+            signal_turnover(window_signal),
+            cost_bps_per_turnover=cost_bps_per_turnover,
+        )
+        window_summary = _summarize_return_modes(
+            window_pre_cost, window_post_cost, cost_bps_per_turnover=cost_bps_per_turnover
+        )
+
+        signal_parts.append(window_signal)
+        pre_cost_parts.append(window_pre_cost)
+        post_cost_parts.append(window_post_cost)
+        windows.append(
+            StandalonePredictorWindow(
+                index=window_index,
+                train_start=train_slice.index.min(),
+                train_end=train_slice.index.max(),
+                forecast_start=effective_forecast.index.min(),
+                forecast_end=effective_forecast.index.max(),
+                n_train_obs=int(train_slice.shape[0]),
+                n_forecast_obs=int(effective_forecast.shape[0]),
+                n_knots_effective=spline_result.n_knots_effective,
+                summary=window_summary,
+            )
+        )
+
+    combined_signal = pd.concat(signal_parts).astype(np.int8)
+    combined_signal.name = "signal"
+    pre_cost_returns = pd.concat(pre_cost_parts)
+    post_cost_returns = pd.concat(post_cost_parts)
+    summary = _summarize_return_modes(
+        pre_cost_returns, post_cost_returns, cost_bps_per_turnover=cost_bps_per_turnover
+    )
+
+    return StandalonePredictorResult(
+        config=config,
+        windows=tuple(windows),
+        signal=combined_signal,
+        pre_cost_returns=pre_cost_returns,
+        post_cost_returns=post_cost_returns,
+        summary=summary,
+        cost_bps_per_turnover=float(cost_bps_per_turnover),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Experiment config (data source + standalone predictor config)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class StandaloneExperimentConfig:
+    """Full recipe for one standalone-predictor experiment run.
+
+    Mirrors :class:`~hft_hmm.config.experiment_config.ExperimentConfig` but
+    replaces the HMM walk-forward config with :class:`StandaloneWalkForwardConfig`
+    and adds predictor-specific sub-configs.
+
+    References: §4 side-information predictor standalone evaluation (evaluation layer)
+    """
+
+    data: DataSourceConfig
+    frequency: Frequency
+    predictor: PredictorKind
+    walk_forward: StandaloneWalkForwardConfig
+    spline: SplinePredictorConfig = field(default_factory=SplinePredictorConfig)
+    vol_ratio: VolatilityRatioConfig = field(default_factory=VolatilityRatioConfig)
+    seasonality: SeasonalityConfig = field(default_factory=SeasonalityConfig)
+    cost_bps_per_turnover: float = 0.0
+    notes: str = ""
+    sha256: str | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.data, DataSourceConfig):
+            raise TypeError(f"data must be a DataSourceConfig, got {type(self.data).__name__}.")
+        if self.frequency not in _VALID_FREQUENCIES:
+            raise ValueError(
+                f"frequency must be one of {_VALID_FREQUENCIES}, got {self.frequency!r}."
+            )
+        if self.predictor not in _PREDICTOR_KINDS:
+            raise ValueError(
+                f"predictor must be one of {_PREDICTOR_KINDS}, got {self.predictor!r}."
+            )
+        if not isinstance(self.walk_forward, StandaloneWalkForwardConfig):
+            raise TypeError(
+                "walk_forward must be a StandaloneWalkForwardConfig, "
+                f"got {type(self.walk_forward).__name__}."
+            )
+        cost = float(self.cost_bps_per_turnover)
+        if not math.isfinite(cost) or cost < 0.0:
+            raise ValueError(
+                f"cost_bps_per_turnover must be a finite non-negative float, got {cost!r}."
+            )
+        object.__setattr__(self, "cost_bps_per_turnover", cost)
+
+        if self.data.is_reproducible:
+            if self.sha256 is None:
+                raise ValueError("StandaloneExperimentConfig for file-backed data requires sha256.")
+            normalized = self.sha256.lower()
+            if len(normalized) != _SHA256_HEX_LENGTH or any(
+                c not in "0123456789abcdef" for c in normalized
+            ):
+                raise ValueError(
+                    f"sha256 must be a {_SHA256_HEX_LENGTH}-character hex digest, "
+                    f"got {self.sha256!r}."
+                )
+            object.__setattr__(self, "sha256", normalized)
+        elif self.sha256 is not None:
+            raise ValueError("sha256 must not be set for non-file-backed data.")
+
+    @property
+    def is_reproducible(self) -> bool:
+        """``True`` when the run is file-backed and pinned to a specific file digest."""
+        return self.data.is_reproducible and self.sha256 is not None
+
+    def to_predictor_config(self) -> StandalonePredictorConfig:
+        """Return the inner predictor config for passing to ``standalone_predictor_backtest``."""
+        return StandalonePredictorConfig(
+            predictor=self.predictor,
+            walk_forward=self.walk_forward,
+            spline=self.spline,
+            vol_ratio=self.vol_ratio,
+            seasonality=self.seasonality,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        wf = self.walk_forward
+        assert wf.retrain_every_days is not None
+        return {
+            "cost_bps_per_turnover": float(self.cost_bps_per_turnover),
+            "data": self.data.to_dict(),
+            "frequency": self.frequency,
+            "notes": self.notes,
+            "predictor": self.predictor,
+            "seasonality": {
+                "bucket_minutes": int(self.seasonality.bucket_minutes),
+                "exchange_tz": str(self.seasonality.exchange_tz),
+                "normalize": bool(self.seasonality.normalize),
+            },
+            "sha256": self.sha256,
+            "spline": {
+                "degree": int(self.spline.degree),
+                "demean": bool(self.spline.demean),
+                "demean_grid_size": int(self.spline.demean_grid_size),
+                "min_obs": int(self.spline.min_obs),
+                "n_knots": int(self.spline.n_knots),
+            },
+            "vol_ratio": {
+                "decay": float(self.vol_ratio.decay),
+                "fast_window": int(self.vol_ratio.fast_window),
+                "slow_window": int(self.vol_ratio.slow_window),
+            },
+            "walk_forward": {
+                "h_days": int(wf.h_days),
+                "retrain_every_days": int(wf.retrain_every_days),
+                "t_days": int(wf.t_days),
+            },
+        }
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> StandaloneExperimentConfig:
+        wf_raw = raw["walk_forward"]
+        walk_forward = StandaloneWalkForwardConfig(
+            h_days=int(wf_raw["h_days"]),
+            t_days=int(wf_raw["t_days"]),
+            retrain_every_days=int(wf_raw["retrain_every_days"])
+            if "retrain_every_days" in wf_raw
+            else None,
+        )
+        sp_raw = raw.get("spline", {})
+        spline = SplinePredictorConfig(
+            n_knots=int(sp_raw.get("n_knots", 5)),
+            degree=int(sp_raw.get("degree", 3)),
+            min_obs=int(sp_raw.get("min_obs", 20)),
+            demean=bool(sp_raw.get("demean", False)),
+            demean_grid_size=int(sp_raw.get("demean_grid_size", 1000)),
+        )
+        vr_raw = raw.get("vol_ratio", {})
+        vol_ratio = VolatilityRatioConfig(
+            decay=float(vr_raw.get("decay", 0.79)),
+            fast_window=int(vr_raw.get("fast_window", 50)),
+            slow_window=int(vr_raw.get("slow_window", 100)),
+        )
+        s_raw = raw.get("seasonality", {})
+        seasonality = SeasonalityConfig(
+            exchange_tz=str(s_raw.get("exchange_tz", "America/Chicago")),
+            bucket_minutes=int(s_raw.get("bucket_minutes", 1)),
+            normalize=bool(s_raw.get("normalize", True)),
+        )
+        return cls(
+            data=DataSourceConfig.from_dict(raw["data"]),
+            frequency=raw["frequency"],
+            predictor=raw["predictor"],
+            walk_forward=walk_forward,
+            spline=spline,
+            vol_ratio=vol_ratio,
+            seasonality=seasonality,
+            cost_bps_per_turnover=float(raw.get("cost_bps_per_turnover", 0.0)),
+            notes=str(raw.get("notes", "")),
+            sha256=raw.get("sha256"),
+        )
+
+    def to_yaml_bytes(self) -> bytes:
+        """Canonical UTF-8 YAML bytes — the exact input to :func:`standalone_run_id`."""
+        return yaml.safe_dump(
+            self.to_dict(),
+            sort_keys=True,
+            default_flow_style=False,
+            allow_unicode=False,
+            width=1_000_000,
+        ).encode("utf-8")
+
+    @classmethod
+    def from_yaml(cls, path: str | Path) -> StandaloneExperimentConfig:
+        raw = yaml.safe_load(Path(path).read_text(encoding="utf-8"))
+        if not isinstance(raw, dict):
+            raise ValueError(
+                f"YAML at {path} must decode to a mapping, got {type(raw).__name__}."
+            )
+        return cls.from_dict(raw)
+
+
+def standalone_run_id(config: StandaloneExperimentConfig) -> str:
+    """Return the 12-char hex run id derived from the config's canonical YAML bytes.
+
+    Two configs hash to the same id iff they produce the same canonical YAML
+    output, mirroring :func:`~hft_hmm.config.experiment_config.run_id`.
+
+    References: §4.4 reproducible simulation artifacts (evaluation layer)
+    """
+    if not isinstance(config, StandaloneExperimentConfig):
+        raise TypeError(
+            f"config must be a StandaloneExperimentConfig, got {type(config).__name__}."
+        )
+    return hashlib.sha256(config.to_yaml_bytes()).hexdigest()[:12]
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class StandaloneRunArtifacts:
+    """Handle returned by :func:`run_standalone_experiment`."""
+
+    run_id: str
+    directory: Path
+    config: StandaloneExperimentConfig
+    result: StandalonePredictorResult
+
+
+def run_standalone_experiment(
+    config: StandaloneExperimentConfig,
+    *,
+    runs_root: Path | str = Path("runs"),
+    force: bool = False,
+) -> StandaloneRunArtifacts:
+    """Run the standalone predictor experiment described by ``config`` and write artifacts.
+
+    The target directory is ``runs_root / standalone_run_id(config)``. If it
+    already exists, ``force=True`` wipes it before writing; otherwise a
+    :exc:`FileExistsError` is raised.
+
+    References: §4 side-information predictor standalone evaluation (evaluation layer)
+    """
+    if not isinstance(config, StandaloneExperimentConfig):
+        raise TypeError(
+            f"config must be a StandaloneExperimentConfig, got {type(config).__name__}."
+        )
+    runs_root_path = Path(runs_root)
+    experiment_id = standalone_run_id(config)
+    run_dir = runs_root_path / experiment_id
+
+    if run_dir.exists() and not force:
+        raise FileExistsError(
+            f"Run directory already exists at {run_dir}; pass force=True to overwrite."
+        )
+
+    reproducible = _validate_standalone_reproducibility(config)
+    returns = _load_returns(config)
+    predictor_config = config.to_predictor_config()
+    result = standalone_predictor_backtest(
+        returns,
+        predictor_config,
+        cost_bps_per_turnover=config.cost_bps_per_turnover,
+    )
+
+    runs_root_path.mkdir(parents=True, exist_ok=True)
+    staging_dir = Path(tempfile.mkdtemp(prefix=f"{experiment_id}.tmp-", dir=runs_root_path))
+    backup_dir: Path | None = None
+    try:
+        _write_artifacts(staging_dir, config, experiment_id, result, reproducible=reproducible)
+        if run_dir.exists():
+            backup_dir = run_dir.with_name(f"{run_dir.name}.backup-{uuid.uuid4().hex}")
+            os.replace(run_dir, backup_dir)
+        try:
+            os.replace(staging_dir, run_dir)
+        except Exception:
+            if backup_dir is not None and backup_dir.exists():
+                os.replace(backup_dir, run_dir)
+            raise
+        if backup_dir is not None:
+            shutil.rmtree(backup_dir, ignore_errors=True)
+    except Exception:
+        if staging_dir.exists():
+            shutil.rmtree(staging_dir, ignore_errors=True)
+        raise
+
+    return StandaloneRunArtifacts(
+        run_id=experiment_id,
+        directory=run_dir,
+        config=config,
+        result=result,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_feature(
+    returns: pd.Series,
+    config: StandalonePredictorConfig,
+) -> pd.Series:
+    """Return the side-information feature series aligned to ``returns.index``."""
+    if config.predictor == "volatility_ratio":
+        return volatility_ratio(
+            returns,
+            fast_window=config.vol_ratio.fast_window,
+            slow_window=config.vol_ratio.slow_window,
+            decay=config.vol_ratio.decay,
+        )
+    # seasonality only looks at the DatetimeIndex, not the values.
+    return intraday_seasonality(returns, config=config.seasonality)
+
+
+def _validate_returns(returns: pd.Series) -> None:
+    if not isinstance(returns, pd.Series):
+        raise TypeError(f"returns must be a pd.Series, got {type(returns).__name__}.")
+    if not isinstance(returns.index, pd.DatetimeIndex):
+        raise TypeError("returns.index must be a pd.DatetimeIndex.")
+    if returns.index.tz is None:
+        raise ValueError("returns.index must be tz-aware; localize to UTC before calling.")
+    if not returns.index.is_monotonic_increasing:
+        raise ValueError("returns.index must be monotonically increasing.")
+    if returns.index.has_duplicates:
+        raise ValueError("returns.index must not contain duplicates.")
+    if not np.all(np.isfinite(np.asarray(returns, dtype=float))):
+        raise ValueError("returns must contain only finite values; drop NaN/inf first.")
+
+
+def _summarize_return_modes(
+    pre_cost_returns: pd.Series,
+    post_cost_returns: pd.Series,
+    *,
+    cost_bps_per_turnover: float,
+) -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            _summary_row(pre_cost_returns, cost_bps_per_turnover=0.0),
+            _summary_row(post_cost_returns, cost_bps_per_turnover=cost_bps_per_turnover),
+        ],
+        index=pd.Index(["pre-cost", "post-cost"], name="mode"),
+    )
+
+
+def _summary_row(
+    strategy_returns: pd.Series,
+    *,
+    cost_bps_per_turnover: float,
+) -> dict[str, float | int]:
+    return {
+        "n_periods": int(strategy_returns.shape[0]),
+        "cost_bps_per_turnover": float(cost_bps_per_turnover),
+        "cumulative_return": cumulative_return(strategy_returns),
+        "sharpe_ratio": sharpe_ratio(strategy_returns),
+        "max_drawdown": max_drawdown(strategy_returns),
+        "hit_rate": hit_rate(strategy_returns),
+    }
+
+
+def _load_returns(config: StandaloneExperimentConfig) -> pd.Series:
+    from hft_hmm.data import (
+        load_csv_market_data,
+        load_databento_parquet,
+        load_yfinance_market_data,
+    )
+    from hft_hmm.preprocessing import compute_log_returns, resample_prices
+
+    if config.data.kind == "csv":
+        assert config.data.path is not None
+        frame = load_csv_market_data(config.data.path)
+    elif config.data.kind == "databento_parquet":
+        assert config.data.path is not None
+        assert config.data.symbol is not None
+        frame = load_databento_parquet(config.data.path, symbol=config.data.symbol)
+    else:
+        assert config.data.symbol is not None
+        assert config.data.start is not None and config.data.end is not None
+        frame = load_yfinance_market_data(
+            config.data.symbol,
+            start=config.data.start,
+            end=config.data.end,
+            interval=_YFINANCE_INTERVAL[config.frequency],
+        )
+
+    resampled = resample_prices(frame, freq=config.frequency)
+    prices = resampled.set_index("timestamp")["price"]
+    returns = compute_log_returns(prices).dropna()
+    returns.name = "log_return"
+    return returns
+
+
+def _validate_standalone_reproducibility(config: StandaloneExperimentConfig) -> bool:
+    if not config.is_reproducible:
+        warnings.warn(_NON_REPRODUCIBLE_WARNING, UserWarning, stacklevel=3)
+        return False
+    assert config.data.path is not None
+    assert config.sha256 is not None
+    actual = compute_file_sha256(config.data.path)
+    if actual != config.sha256:
+        warnings.warn(
+            _DATA_FINGERPRINT_MISMATCH_WARNING.format(path=config.data.path),
+            UserWarning,
+            stacklevel=3,
+        )
+        return False
+    return True
+
+
+def _write_artifacts(
+    run_dir: Path,
+    config: StandaloneExperimentConfig,
+    experiment_id: str,
+    result: StandalonePredictorResult,
+    *,
+    reproducible: bool,
+) -> None:
+    (run_dir / "figures").mkdir()
+    (run_dir / "config.yaml").write_bytes(config.to_yaml_bytes())
+    _write_metrics(
+        run_dir / "metrics.json", config, experiment_id, result, reproducible=reproducible
+    )
+    _write_log(run_dir / "log.jsonl", result)
+
+
+def _write_metrics(
+    path: Path,
+    config: StandaloneExperimentConfig,
+    experiment_id: str,
+    result: StandalonePredictorResult,
+    *,
+    reproducible: bool,
+) -> None:
+    payload: dict[str, Any] = {
+        "run_id": experiment_id,
+        "reproducible": reproducible,
+        "predictor": config.predictor,
+        "cost_bps_per_turnover": float(config.cost_bps_per_turnover),
+        "n_windows": len(result.windows),
+        "n_forecast_obs": int(result.signal.shape[0]),
+        "summary": _summary_to_payload(result.summary),
+    }
+    path.write_text(
+        json.dumps(payload, sort_keys=True, indent=2, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_log(path: Path, result: StandalonePredictorResult) -> None:
+    lines = []
+    for w in result.windows:
+        lines.append(
+            json.dumps(
+                {
+                    "index": int(w.index),
+                    "train_start": w.train_start.isoformat(),
+                    "train_end": w.train_end.isoformat(),
+                    "forecast_start": w.forecast_start.isoformat(),
+                    "forecast_end": w.forecast_end.isoformat(),
+                    "n_knots_effective": int(w.n_knots_effective),
+                    "n_train_obs": int(w.n_train_obs),
+                    "n_forecast_obs": int(w.n_forecast_obs),
+                    "summary": _summary_to_payload(w.summary),
+                },
+                sort_keys=True,
+                allow_nan=False,
+            )
+        )
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _summary_to_payload(summary: pd.DataFrame) -> dict[str, dict[str, float | None]]:
+    payload: dict[str, dict[str, float | None]] = {}
+    for mode, row in summary.iterrows():
+        payload[str(mode)] = {str(col): _json_safe(row[col]) for col in summary.columns}
+    return payload
+
+
+def _json_safe(value: Any) -> float | None:
+    if pd.isna(value):
+        return None
+    numeric = float(value)
+    if not math.isfinite(numeric):
+        return None
+    return round(numeric, 8)

--- a/src/hft_hmm/experiments/standalone_predictor.py
+++ b/src/hft_hmm/experiments/standalone_predictor.py
@@ -259,9 +259,7 @@ def standalone_predictor_backtest(
     References: §4 side-information predictor standalone evaluation (evaluation layer)
     """
     if not isinstance(config, StandalonePredictorConfig):
-        raise TypeError(
-            f"config must be a StandalonePredictorConfig, got {type(config).__name__}."
-        )
+        raise TypeError(f"config must be a StandalonePredictorConfig, got {type(config).__name__}.")
     if not np.isfinite(cost_bps_per_turnover) or cost_bps_per_turnover < 0.0:
         raise ValueError(
             "cost_bps_per_turnover must be a finite non-negative float, "
@@ -532,9 +530,9 @@ class StandaloneExperimentConfig:
         walk_forward = StandaloneWalkForwardConfig(
             h_days=int(wf_raw["h_days"]),
             t_days=int(wf_raw["t_days"]),
-            retrain_every_days=int(wf_raw["retrain_every_days"])
-            if "retrain_every_days" in wf_raw
-            else None,
+            retrain_every_days=(
+                int(wf_raw["retrain_every_days"]) if "retrain_every_days" in wf_raw else None
+            ),
         )
         sp_raw = raw.get("spline", {})
         spline = SplinePredictorConfig(
@@ -583,9 +581,7 @@ class StandaloneExperimentConfig:
     def from_yaml(cls, path: str | Path) -> StandaloneExperimentConfig:
         raw = yaml.safe_load(Path(path).read_text(encoding="utf-8"))
         if not isinstance(raw, dict):
-            raise ValueError(
-                f"YAML at {path} must decode to a mapping, got {type(raw).__name__}."
-            )
+            raise ValueError(f"YAML at {path} must decode to a mapping, got {type(raw).__name__}.")
         return cls.from_dict(raw)
 
 

--- a/tests/test_repro.py
+++ b/tests/test_repro.py
@@ -127,9 +127,7 @@ def test_run_experiment_force_preserves_previous_run_if_replacement_fails(
     def broken_loader(path):  # type: ignore[no-untyped-def]
         raise RuntimeError("boom")
 
-    monkeypatch.setattr(
-        "hft_hmm.experiments._data_loading.load_csv_market_data", broken_loader
-    )
+    monkeypatch.setattr("hft_hmm.experiments._data_loading.load_csv_market_data", broken_loader)
     with pytest.raises(RuntimeError, match="boom"):
         run_experiment(config, runs_root=tmp_path, force=True)
 
@@ -387,10 +385,7 @@ def test_repro_cli_warns_when_standalone_config_contains_hmm_only_fields(
         cwd=REPO_ROOT,
     )
 
-    assert (
-        "HMM-only walk_forward fields will be ignored: k_values, n_iter"
-        in completed.stderr
-    )
+    assert "HMM-only walk_forward fields will be ignored: k_values, n_iter" in completed.stderr
 
 
 def test_repro_cli_example_config_emits_no_convergence_warning(tmp_path: Path) -> None:

--- a/tests/test_repro.py
+++ b/tests/test_repro.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 import pytest
+import yaml
 
 from hft_hmm.config import DataSourceConfig, ExperimentConfig, compute_file_sha256, run_id
 from hft_hmm.core import EVALUATION_LAYER
@@ -126,7 +127,9 @@ def test_run_experiment_force_preserves_previous_run_if_replacement_fails(
     def broken_loader(path):  # type: ignore[no-untyped-def]
         raise RuntimeError("boom")
 
-    monkeypatch.setattr("hft_hmm.experiments.runner.load_csv_market_data", broken_loader)
+    monkeypatch.setattr(
+        "hft_hmm.experiments._data_loading.load_csv_market_data", broken_loader
+    )
     with pytest.raises(RuntimeError, match="boom"):
         run_experiment(config, runs_root=tmp_path, force=True)
 
@@ -150,7 +153,7 @@ def test_run_experiment_emits_non_reproducible_warning_for_yfinance(
         return sample.copy()
 
     monkeypatch.setattr(
-        "hft_hmm.experiments.runner.load_yfinance_market_data",
+        "hft_hmm.experiments._data_loading.load_yfinance_market_data",
         fake_yfinance_loader,
     )
     cfg = ExperimentConfig(
@@ -355,6 +358,39 @@ def test_repro_cli_runs_standalone_predictor_config_end_to_end(tmp_path: Path) -
     assert metrics["reproducible"] is True
     assert metrics["n_windows"] >= 1
     assert np.isfinite(metrics["summary"]["post-cost"]["sharpe_ratio"])
+
+
+def test_repro_cli_warns_when_standalone_config_contains_hmm_only_fields(
+    tmp_path: Path,
+) -> None:
+    config = StandaloneExperimentConfig.from_yaml(STANDALONE_VOL_CONFIG)
+    raw = config.to_dict()
+    walk_forward = raw["walk_forward"]
+    assert isinstance(walk_forward, dict)
+    walk_forward["k_values"] = [2]
+    walk_forward["n_iter"] = 100
+
+    config_yaml = tmp_path / "standalone_with_hmm_fields.yaml"
+    config_yaml.write_text(yaml.safe_dump(raw), encoding="utf-8")
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(REPRO_SCRIPT),
+            str(config_yaml),
+            "--runs-root",
+            str(tmp_path / "runs"),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+
+    assert (
+        "HMM-only walk_forward fields will be ignored: k_values, n_iter"
+        in completed.stderr
+    )
 
 
 def test_repro_cli_example_config_emits_no_convergence_warning(tmp_path: Path) -> None:

--- a/tests/test_repro.py
+++ b/tests/test_repro.py
@@ -21,6 +21,10 @@ from hft_hmm.experiments.runner import (
     NON_REPRODUCIBLE_WARNING,
     run_experiment,
 )
+from hft_hmm.experiments.standalone_predictor import (
+    StandaloneExperimentConfig,
+    standalone_run_id,
+)
 from hft_hmm.experiments.walk_forward import (
     WalkForwardConfig,
     WalkForwardResult,
@@ -31,6 +35,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 SAMPLE_FIXTURE = REPO_ROOT / "tests" / "fixtures" / "es_1min_sample.csv"
 MONTH_FIXTURE = REPO_ROOT / "tests" / "fixtures" / "es_1min_month.csv"
 EXAMPLE_CONFIG = REPO_ROOT / "configs" / "example_es_csv.yaml"
+STANDALONE_VOL_CONFIG = REPO_ROOT / "configs" / "example_es_vol_ratio_standalone.yaml"
 REPRO_SCRIPT = REPO_ROOT / "scripts" / "repro.py"
 SAMPLE_SHA256 = compute_file_sha256(SAMPLE_FIXTURE)
 
@@ -318,6 +323,35 @@ def test_repro_cli_runs_example_config_end_to_end(tmp_path: Path) -> None:
     printed = Path(completed.stdout.strip())
     assert printed.is_dir()
     metrics = json.loads((printed / "metrics.json").read_text())
+    assert metrics["reproducible"] is True
+    assert metrics["n_windows"] >= 1
+    assert np.isfinite(metrics["summary"]["post-cost"]["sharpe_ratio"])
+
+
+def test_repro_cli_runs_standalone_predictor_config_end_to_end(tmp_path: Path) -> None:
+    runs_root = tmp_path / "runs"
+    config = StandaloneExperimentConfig.from_yaml(STANDALONE_VOL_CONFIG)
+    expected_id = standalone_run_id(config)
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(REPRO_SCRIPT),
+            str(STANDALONE_VOL_CONFIG),
+            "--runs-root",
+            str(runs_root),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+
+    printed = Path(completed.stdout.strip())
+    assert printed == runs_root / expected_id
+    assert printed.is_dir()
+    metrics = json.loads((printed / "metrics.json").read_text())
+    assert metrics["predictor"] == "volatility_ratio"
     assert metrics["reproducible"] is True
     assert metrics["n_windows"] >= 1
     assert np.isfinite(metrics["summary"]["post-cost"]["sharpe_ratio"])

--- a/tests/test_standalone_predictor.py
+++ b/tests/test_standalone_predictor.py
@@ -162,6 +162,21 @@ def test_standalone_predictor_config_rejects_invalid_subconfigs() -> None:
         )
 
 
+def test_standalone_experiment_config_rejects_non_string_sha256() -> None:
+    from hft_hmm.config.experiment_config import DataSourceConfig
+
+    with pytest.raises(ValueError, match="sha256 must be a string"):
+        StandaloneExperimentConfig(
+            data=DataSourceConfig(kind="csv", path=str(FIXTURE_CSV)),
+            frequency="1min",
+            predictor="volatility_ratio",
+            walk_forward=StandaloneWalkForwardConfig(
+                h_days=10, t_days=2, retrain_every_days=2
+            ),
+            sha256=123,  # type: ignore[arg-type]
+        )
+
+
 # ---------------------------------------------------------------------------
 # Two-window walk-forward on synthetic fixture
 # ---------------------------------------------------------------------------

--- a/tests/test_standalone_predictor.py
+++ b/tests/test_standalone_predictor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib
+import json
 from pathlib import Path
 
 import numpy as np
@@ -16,6 +17,7 @@ from hft_hmm.experiments.standalone_predictor import (
     StandalonePredictorResult,
     StandalonePredictorWindow,
     StandaloneWalkForwardConfig,
+    run_standalone_experiment,
     standalone_predictor_backtest,
     standalone_run_id,
 )
@@ -139,6 +141,27 @@ def test_standalone_predictor_config_rejects_unknown_predictor() -> None:
         )
 
 
+def test_standalone_predictor_config_rejects_invalid_subconfigs() -> None:
+    with pytest.raises(TypeError, match="spline"):
+        StandalonePredictorConfig(
+            predictor="volatility_ratio",
+            walk_forward=StandaloneWalkForwardConfig(),
+            spline={"n_knots": 3},  # type: ignore[arg-type]
+        )
+    with pytest.raises(TypeError, match="vol_ratio"):
+        StandalonePredictorConfig(
+            predictor="volatility_ratio",
+            walk_forward=StandaloneWalkForwardConfig(),
+            vol_ratio={"fast_window": 10},  # type: ignore[arg-type]
+        )
+    with pytest.raises(TypeError, match="seasonality"):
+        StandalonePredictorConfig(
+            predictor="seasonality",
+            walk_forward=StandaloneWalkForwardConfig(),
+            seasonality={"bucket_minutes": 5},  # type: ignore[arg-type]
+        )
+
+
 # ---------------------------------------------------------------------------
 # Two-window walk-forward on synthetic fixture
 # ---------------------------------------------------------------------------
@@ -156,6 +179,22 @@ def test_vol_ratio_standalone_covers_two_windows() -> None:
         assert isinstance(w, StandalonePredictorWindow)
         assert w.n_forecast_obs >= 2
         assert isinstance(w.summary, pd.DataFrame)
+
+
+def test_backtest_rejects_non_config() -> None:
+    returns = _make_returns(n_days=10, bars_per_day=300, seed=0)
+    with pytest.raises(TypeError, match="StandalonePredictorConfig"):
+        standalone_predictor_backtest(returns, {"predictor": "volatility_ratio"})  # type: ignore[arg-type]
+
+
+def test_backtest_rejects_invalid_cost() -> None:
+    returns = _make_returns(n_days=10, bars_per_day=300, seed=0)
+    with pytest.raises(ValueError, match="cost_bps_per_turnover"):
+        standalone_predictor_backtest(
+            returns,
+            _vol_ratio_config(),
+            cost_bps_per_turnover=-1.0,
+        )
 
 
 def test_seasonality_standalone_covers_two_windows() -> None:
@@ -352,6 +391,35 @@ def test_standalone_experiment_config_yaml_round_trip(tmp_path: Path) -> None:
     assert loaded.vol_ratio.fast_window == cfg.vol_ratio.fast_window
     assert loaded.sha256 == cfg.sha256
     assert standalone_run_id(loaded) == standalone_run_id(cfg)
+
+
+def test_run_standalone_experiment_writes_expected_artifact_layout(tmp_path: Path) -> None:
+    from hft_hmm.config.experiment_config import DataSourceConfig
+
+    cfg = StandaloneExperimentConfig(
+        data=DataSourceConfig(kind="csv", path=str(FIXTURE_CSV)),
+        frequency="1min",
+        predictor="volatility_ratio",
+        walk_forward=StandaloneWalkForwardConfig(h_days=10, t_days=2, retrain_every_days=2),
+        spline=SplinePredictorConfig(n_knots=5, min_obs=20),
+        vol_ratio=VolatilityRatioConfig(fast_window=50, slow_window=100),
+        cost_bps_per_turnover=1.0,
+        notes="artifact-test",
+        sha256=FIXTURE_SHA256,
+    )
+
+    artifacts = run_standalone_experiment(cfg, runs_root=tmp_path)
+
+    assert artifacts.directory == tmp_path / artifacts.run_id
+    assert (artifacts.directory / "config.yaml").is_file()
+    assert (artifacts.directory / "metrics.json").is_file()
+    assert (artifacts.directory / "log.jsonl").is_file()
+    assert (artifacts.directory / "figures").is_dir()
+    metrics = json.loads((artifacts.directory / "metrics.json").read_text())
+    assert metrics["run_id"] == artifacts.run_id
+    assert metrics["predictor"] == "volatility_ratio"
+    assert metrics["reproducible"] is True
+    assert metrics["n_windows"] == len(artifacts.result.windows)
 
 
 def test_standalone_configs_are_loadable() -> None:

--- a/tests/test_standalone_predictor.py
+++ b/tests/test_standalone_predictor.py
@@ -170,9 +170,7 @@ def test_standalone_experiment_config_rejects_non_string_sha256() -> None:
             data=DataSourceConfig(kind="csv", path=str(FIXTURE_CSV)),
             frequency="1min",
             predictor="volatility_ratio",
-            walk_forward=StandaloneWalkForwardConfig(
-                h_days=10, t_days=2, retrain_every_days=2
-            ),
+            walk_forward=StandaloneWalkForwardConfig(h_days=10, t_days=2, retrain_every_days=2),
             sha256=123,  # type: ignore[arg-type]
         )
 
@@ -237,9 +235,9 @@ def test_no_leakage_training_ends_before_forecast_starts() -> None:
     result = standalone_predictor_backtest(returns, config)
 
     for w in result.windows:
-        assert w.train_end < w.forecast_start, (
-            f"window {w.index}: train_end={w.train_end} >= forecast_start={w.forecast_start}"
-        )
+        assert (
+            w.train_end < w.forecast_start
+        ), f"window {w.index}: train_end={w.train_end} >= forecast_start={w.forecast_start}"
 
 
 def test_leakage_guard_assertion_trips_on_overlap(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -290,9 +288,9 @@ def test_standalone_does_not_instantiate_gaussian_hmm(monkeypatch: pytest.Monkey
     config = _vol_ratio_config()
     standalone_predictor_backtest(returns, config)
 
-    assert len(instantiated) == 0, (
-        "GaussianHMMWrapper was instantiated inside the standalone predictor path"
-    )
+    assert (
+        len(instantiated) == 0
+    ), "GaussianHMMWrapper was instantiated inside the standalone predictor path"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_standalone_predictor.py
+++ b/tests/test_standalone_predictor.py
@@ -1,0 +1,366 @@
+"""Tests for standalone predictor walk-forward backtests."""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from hft_hmm.core import EVALUATION_LAYER, module_category
+from hft_hmm.experiments.standalone_predictor import (
+    StandaloneExperimentConfig,
+    StandalonePredictorConfig,
+    StandalonePredictorResult,
+    StandalonePredictorWindow,
+    StandaloneWalkForwardConfig,
+    standalone_predictor_backtest,
+    standalone_run_id,
+)
+from hft_hmm.features.seasonality import SeasonalityConfig
+from hft_hmm.features.splines import SplinePredictorConfig
+from hft_hmm.features.volatility_ratio import VolatilityRatioConfig
+
+standalone_module = importlib.import_module("hft_hmm.experiments.standalone_predictor")
+
+FIXTURE_CSV = Path(__file__).parent / "fixtures" / "es_1min_month.csv"
+FIXTURE_SHA256 = "c81161b1932361e119483a37fa27b2e16ce39020bcfcc3e871812c5cb7a9ca34"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_returns(
+    *,
+    n_days: int,
+    bars_per_day: int,
+    seed: int = 0,
+) -> pd.Series:
+    """Deterministic UTC-aware return series."""
+    rng = np.random.default_rng(seed)
+    total = n_days * bars_per_day
+    values = rng.normal(0.0, 0.01, total)
+    dates = pd.bdate_range("2024-01-02", periods=n_days, tz="UTC")
+    timestamps = [date + pd.Timedelta(minutes=m) for date in dates for m in range(bars_per_day)]
+    index = pd.DatetimeIndex(timestamps, tz="UTC")
+    return pd.Series(values, index=index, name="log_return")
+
+
+def _vol_ratio_config(
+    h_days: int = 5,
+    t_days: int = 2,
+    retrain_every_days: int = 2,
+) -> StandalonePredictorConfig:
+    """Small-window vol-ratio config suitable for synthetic fixtures."""
+    return StandalonePredictorConfig(
+        predictor="volatility_ratio",
+        walk_forward=StandaloneWalkForwardConfig(
+            h_days=h_days, t_days=t_days, retrain_every_days=retrain_every_days
+        ),
+        spline=SplinePredictorConfig(n_knots=3, min_obs=10),
+        vol_ratio=VolatilityRatioConfig(fast_window=10, slow_window=20),
+    )
+
+
+def _seasonality_config(
+    h_days: int = 5,
+    t_days: int = 2,
+    retrain_every_days: int = 2,
+) -> StandalonePredictorConfig:
+    """Seasonality config using 30-min buckets for synthetic fixtures."""
+    return StandalonePredictorConfig(
+        predictor="seasonality",
+        walk_forward=StandaloneWalkForwardConfig(
+            h_days=h_days, t_days=t_days, retrain_every_days=retrain_every_days
+        ),
+        spline=SplinePredictorConfig(n_knots=3, min_obs=10),
+        seasonality=SeasonalityConfig(bucket_minutes=30),
+    )
+
+
+@pytest.fixture
+def es_returns() -> pd.Series:
+    """Log returns from the tracked ES 1-min CSV fixture."""
+    from hft_hmm.data import load_csv_market_data
+    from hft_hmm.preprocessing import compute_log_returns, resample_prices
+
+    frame = load_csv_market_data(str(FIXTURE_CSV))
+    resampled = resample_prices(frame, freq="1min")
+    prices = resampled.set_index("timestamp")["price"]
+    returns = compute_log_returns(prices).dropna()
+    returns.name = "log_return"
+    return returns
+
+
+# ---------------------------------------------------------------------------
+# Module taxonomy
+# ---------------------------------------------------------------------------
+
+
+def test_standalone_module_is_evaluation_layer() -> None:
+    assert module_category(standalone_module) == EVALUATION_LAYER
+
+
+# ---------------------------------------------------------------------------
+# Config validation
+# ---------------------------------------------------------------------------
+
+
+def test_standalone_wf_config_defaults() -> None:
+    cfg = StandaloneWalkForwardConfig()
+    assert cfg.h_days == 23
+    assert cfg.t_days == 1
+    assert cfg.retrain_every_days == 1
+
+
+def test_standalone_wf_config_normalizes_retrain_every_days() -> None:
+    cfg = StandaloneWalkForwardConfig(t_days=3)
+    assert cfg.retrain_every_days == 3
+
+
+def test_standalone_wf_config_rejects_invalid() -> None:
+    with pytest.raises(ValueError, match="h_days"):
+        StandaloneWalkForwardConfig(h_days=0)
+    with pytest.raises(ValueError, match="t_days"):
+        StandaloneWalkForwardConfig(t_days=0)
+    with pytest.raises(ValueError, match="retrain_every_days"):
+        StandaloneWalkForwardConfig(retrain_every_days=0)
+
+
+def test_standalone_predictor_config_rejects_unknown_predictor() -> None:
+    with pytest.raises(ValueError, match="predictor"):
+        StandalonePredictorConfig(
+            predictor="unknown",  # type: ignore[arg-type]
+            walk_forward=StandaloneWalkForwardConfig(),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Two-window walk-forward on synthetic fixture
+# ---------------------------------------------------------------------------
+
+
+def test_vol_ratio_standalone_covers_two_windows() -> None:
+    returns = _make_returns(n_days=10, bars_per_day=300, seed=0)
+    config = _vol_ratio_config()
+
+    result = standalone_predictor_backtest(returns, config)
+
+    assert isinstance(result, StandalonePredictorResult)
+    assert len(result.windows) >= 2
+    for w in result.windows:
+        assert isinstance(w, StandalonePredictorWindow)
+        assert w.n_forecast_obs >= 2
+        assert isinstance(w.summary, pd.DataFrame)
+
+
+def test_seasonality_standalone_covers_two_windows() -> None:
+    returns = _make_returns(n_days=10, bars_per_day=300, seed=1)
+    config = _seasonality_config()
+
+    result = standalone_predictor_backtest(returns, config)
+
+    assert isinstance(result, StandalonePredictorResult)
+    assert len(result.windows) >= 2
+    for w in result.windows:
+        assert isinstance(w, StandalonePredictorWindow)
+        assert w.n_forecast_obs >= 2
+
+
+# ---------------------------------------------------------------------------
+# No-leakage boundary checks
+# ---------------------------------------------------------------------------
+
+
+def test_no_leakage_training_ends_before_forecast_starts() -> None:
+    returns = _make_returns(n_days=10, bars_per_day=300, seed=2)
+    config = _vol_ratio_config()
+
+    result = standalone_predictor_backtest(returns, config)
+
+    for w in result.windows:
+        assert w.train_end < w.forecast_start, (
+            f"window {w.index}: train_end={w.train_end} >= forecast_start={w.forecast_start}"
+        )
+
+
+def test_leakage_guard_assertion_trips_on_overlap(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch Series.loc so the forecast slice overlaps training; the assert must fire."""
+    returns = _make_returns(n_days=8, bars_per_day=100, seed=0)
+    config = _vol_ratio_config(h_days=3, t_days=2, retrain_every_days=2)
+
+    original_loc = pd.Series.loc
+    call_counter = {"n": 0}
+
+    class _OverlapLoc:
+        def __init__(self, s: pd.Series) -> None:
+            self._s = s
+
+        def __getitem__(self, key):  # type: ignore[no-untyped-def]
+            call_counter["n"] += 1
+            if call_counter["n"] == 2:
+                # Return a slice that overlaps the training region.
+                return self._s.iloc[: 3 * 100 + 1]
+            return original_loc.__get__(self._s, pd.Series)[key]
+
+    def _patched(self: pd.Series):  # type: ignore[no-untyped-def]
+        return _OverlapLoc(self)
+
+    monkeypatch.setattr(pd.Series, "loc", property(_patched))
+    with pytest.raises(AssertionError, match="leakage guard"):
+        standalone_predictor_backtest(returns, config)
+
+
+# ---------------------------------------------------------------------------
+# HMM exclusion
+# ---------------------------------------------------------------------------
+
+
+def test_standalone_does_not_instantiate_gaussian_hmm(monkeypatch: pytest.MonkeyPatch) -> None:
+    import hft_hmm.models.gaussian_hmm as hmm_module
+
+    instantiated: list[bool] = []
+    original_init = hmm_module.GaussianHMMWrapper.__init__
+
+    def tracking_init(self, *args, **kwargs) -> None:  # type: ignore[no-untyped-def]
+        instantiated.append(True)
+        original_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(hmm_module.GaussianHMMWrapper, "__init__", tracking_init)
+
+    returns = _make_returns(n_days=10, bars_per_day=300, seed=0)
+    config = _vol_ratio_config()
+    standalone_predictor_backtest(returns, config)
+
+    assert len(instantiated) == 0, (
+        "GaussianHMMWrapper was instantiated inside the standalone predictor path"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Signal and return alignment (strategy contract)
+# ---------------------------------------------------------------------------
+
+
+def test_signal_alignment_follows_strategy_contract() -> None:
+    """pre_cost_returns index must be the tail of each window's forecast index."""
+    returns = _make_returns(n_days=10, bars_per_day=300, seed=3)
+    config = _vol_ratio_config()
+
+    result = standalone_predictor_backtest(returns, config)
+
+    expected_parts: list[pd.Index] = []
+    for w in result.windows:
+        window_signal = result.signal.loc[w.forecast_start : w.forecast_end]
+        # The aligned return series drops the first bar of each window.
+        expected_parts.append(window_signal.index[1:])
+
+    expected_index = expected_parts[0]
+    for part in expected_parts[1:]:
+        expected_index = expected_index.append(part)
+
+    pd.testing.assert_index_equal(result.pre_cost_returns.index, expected_index)
+    pd.testing.assert_index_equal(result.post_cost_returns.index, expected_index)
+
+
+def test_signal_and_returns_have_consistent_lengths() -> None:
+    returns = _make_returns(n_days=10, bars_per_day=300, seed=4)
+    config = _seasonality_config()
+
+    result = standalone_predictor_backtest(returns, config)
+
+    n_windows = len(result.windows)
+    total_signal = result.signal.shape[0]
+    total_returns = result.pre_cost_returns.shape[0]
+    # Each window drops its first bar when aligning signal with future return.
+    assert total_returns == total_signal - n_windows
+
+
+# ---------------------------------------------------------------------------
+# Finite metrics — integration tests on the tracked ES fixture
+# ---------------------------------------------------------------------------
+
+
+def test_vol_ratio_standalone_on_fixture_produces_finite_metrics(
+    es_returns: pd.Series,
+) -> None:
+    config = StandalonePredictorConfig(
+        predictor="volatility_ratio",
+        walk_forward=StandaloneWalkForwardConfig(h_days=10, t_days=2, retrain_every_days=2),
+        spline=SplinePredictorConfig(n_knots=5, min_obs=20),
+        vol_ratio=VolatilityRatioConfig(fast_window=50, slow_window=100),
+    )
+
+    result = standalone_predictor_backtest(es_returns, config, cost_bps_per_turnover=1.0)
+
+    assert len(result.windows) >= 2
+    for col in ("cumulative_return", "sharpe_ratio", "max_drawdown", "hit_rate"):
+        for mode in ("pre-cost", "post-cost"):
+            val = result.summary.loc[mode, col]
+            assert np.isfinite(float(val)), f"{mode} {col} is not finite: {val}"
+
+
+def test_seasonality_standalone_on_fixture_produces_finite_metrics(
+    es_returns: pd.Series,
+) -> None:
+    config = StandalonePredictorConfig(
+        predictor="seasonality",
+        walk_forward=StandaloneWalkForwardConfig(h_days=10, t_days=2, retrain_every_days=2),
+        spline=SplinePredictorConfig(n_knots=5, min_obs=20),
+        seasonality=SeasonalityConfig(bucket_minutes=1, exchange_tz="America/Chicago"),
+    )
+
+    result = standalone_predictor_backtest(es_returns, config, cost_bps_per_turnover=1.0)
+
+    assert len(result.windows) >= 2
+    for col in ("cumulative_return", "sharpe_ratio", "max_drawdown", "hit_rate"):
+        for mode in ("pre-cost", "post-cost"):
+            val = result.summary.loc[mode, col]
+            assert np.isfinite(float(val)), f"{mode} {col} is not finite: {val}"
+
+
+# ---------------------------------------------------------------------------
+# StandaloneExperimentConfig YAML round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_standalone_experiment_config_yaml_round_trip(tmp_path: Path) -> None:
+    from hft_hmm.config.experiment_config import DataSourceConfig
+
+    cfg = StandaloneExperimentConfig(
+        data=DataSourceConfig(kind="csv", path="tests/fixtures/es_1min_month.csv"),
+        frequency="1min",
+        predictor="volatility_ratio",
+        walk_forward=StandaloneWalkForwardConfig(h_days=10, t_days=2, retrain_every_days=2),
+        spline=SplinePredictorConfig(n_knots=5),
+        vol_ratio=VolatilityRatioConfig(fast_window=50, slow_window=100),
+        cost_bps_per_turnover=1.0,
+        notes="test",
+        sha256=FIXTURE_SHA256,
+    )
+
+    yaml_path = tmp_path / "config.yaml"
+    yaml_path.write_bytes(cfg.to_yaml_bytes())
+    loaded = StandaloneExperimentConfig.from_yaml(yaml_path)
+
+    assert loaded.predictor == cfg.predictor
+    assert loaded.walk_forward.h_days == cfg.walk_forward.h_days
+    assert loaded.vol_ratio.fast_window == cfg.vol_ratio.fast_window
+    assert loaded.sha256 == cfg.sha256
+    assert standalone_run_id(loaded) == standalone_run_id(cfg)
+
+
+def test_standalone_configs_are_loadable() -> None:
+    """Both tracked YAML configs round-trip through StandaloneExperimentConfig."""
+    configs_root = Path(__file__).parent.parent / "configs"
+    for name in (
+        "example_es_vol_ratio_standalone.yaml",
+        "example_es_seasonality_standalone.yaml",
+    ):
+        cfg = StandaloneExperimentConfig.from_yaml(configs_root / name)
+        assert cfg.predictor in ("volatility_ratio", "seasonality")
+        assert cfg.sha256 == FIXTURE_SHA256


### PR DESCRIPTION
## Issue

Closes #35.

## Summary

- Adds standalone walk-forward backtests for volatility-ratio and intraday-seasonality spline predictors.
- Fits `f(x_t) ~= E[r_{t+1} | x_t]` on each training window only, then generates out-of-sample `sign(f(x_t))` forecast signals.
- Reuses the existing signal alignment, turnover-cost, and metric helpers so the output is comparable to the baseline HMM walk-forward path.
- Adds standalone experiment config/YAML serialization, artifact writing, and two tracked example configs.
- Extends `scripts/repro.py` with backward-compatible dispatch for standalone predictor configs.

## Review Notes

I reviewed the pushed branch before opening this PR and added one follow-up commit:

- wired the new standalone YAML configs through `scripts/repro.py`
- added validation for standalone predictor config subobjects and invalid cost inputs
- added artifact-layout coverage for `run_standalone_experiment`
- added CLI coverage for running a standalone config end to end

No HMM object or HMM inference path is used by the standalone backtest.

## Checks

- [x] `.venv/bin/python -m pytest -q tests/test_standalone_predictor.py`
- [x] `.venv/bin/python -m pytest -q tests/test_standalone_predictor.py tests/test_repro.py`
- [x] `.venv/bin/python -m pytest -q`
- [x] `.venv/bin/python -m ruff check .`
- [x] `.venv/bin/python -m mypy src`
- [x] `.venv/bin/python scripts/repro.py configs/example_es_vol_ratio_standalone.yaml --runs-root /tmp/hmm-standalone-runs --force`
- [x] `.venv/bin/python scripts/repro.py configs/example_es_seasonality_standalone.yaml --runs-root /tmp/hmm-standalone-runs --force`
- [ ] `black --check .` skipped per request

## Implementation Type

- [ ] Paper-faithful implementation
- [ ] Engineering approximation
- [x] Evaluation-layer utility


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standalone predictor backtesting with walk-forward intraday evaluation.
  * Example configs for seasonality and volatility-ratio prediction included.
  * CLI now accepts standalone predictor runs and emits warnings for ignored config fields.

* **Reliability**
  * Dataset integrity checks with sha256-based reproducibility validation and user warnings.
  * Centralized market-data loading and preprocessing for consistent results.

* **Tests**
  * Expanded end-to-end and unit tests covering standalone predictor flows and reproducibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->