### PR TITLE
Issue 16 - IOHMM-style transition conditioning approximation

### DIFF
--- a/src/hft_hmm/models/__init__.py
+++ b/src/hft_hmm/models/__init__.py
@@ -1,6 +1,12 @@
 """Model-building primitives used by the HMM trading project."""
 
 from hft_hmm.models.gaussian_hmm import GaussianHMMResult, GaussianHMMWrapper
+from hft_hmm.models.iohmm_approx import (
+    BucketedTransitionConfig,
+    BucketedTransitionResult,
+    bucket_boundaries_from_spline_grid,
+    fit_bucketed_transition_model,
+)
 from hft_hmm.models.plr_baseline import (
     PLRBaselineResult,
     PLRSegment,
@@ -8,15 +14,20 @@ from hft_hmm.models.plr_baseline import (
     fit_piecewise_linear_regression,
 )
 
-from . import gaussian_hmm, plr_baseline
+from . import gaussian_hmm, iohmm_approx, plr_baseline
 
 __all__ = [
+    "BucketedTransitionConfig",
+    "BucketedTransitionResult",
     "GaussianHMMResult",
     "GaussianHMMWrapper",
     "PLRBaselineResult",
     "PLRSegment",
     "PLRStateSummary",
+    "bucket_boundaries_from_spline_grid",
+    "fit_bucketed_transition_model",
     "fit_piecewise_linear_regression",
     "gaussian_hmm",
+    "iohmm_approx",
     "plr_baseline",
 ]

--- a/src/hft_hmm/models/iohmm_approx.py
+++ b/src/hft_hmm/models/iohmm_approx.py
@@ -1,0 +1,357 @@
+"""Bucketed transition-matrix approximation for IOHMM-style side-information conditioning.
+
+This module is an **engineering approximation** to the IOHMM transition model
+described in §4 of Christensen, Turner & Godsill (2020).  The paper conditions
+the HMM transition matrix on a side-information variable x_t through a
+continuous parametric form; this module replaces that with a finite-bucket
+scheme:
+
+  1. Partition the support of x_t into ``n_buckets`` intervals.
+  2. Assign each transition (s_t → s_{t+1}) to the bucket that contains x_t.
+  3. Estimate one K × K row-stochastic transition matrix per bucket using
+     additive smoothing toward a pooled baseline matrix.
+
+The result is deterministic, interpretable, and directly usable in Gate H
+experiments where a lookup ``A(x_t)`` replaces the fixed HMM transition matrix.
+
+**This is NOT the exact IOHMM model from the paper.** It is a finite-bucket
+engineering approximation intended for Gate H experiments only.  The paper's
+continuous parametric conditioning is out of scope for the current coursework.
+
+References: §4 side-information / IOHMM approximation
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Final, cast
+
+import numpy as np
+
+from hft_hmm.core import ENGINEERING_APPROXIMATION, PaperReference, reference
+
+if TYPE_CHECKING:
+    from hft_hmm.features.splines import SplinePredictorResult
+
+__category__: Final[str] = ENGINEERING_APPROXIMATION
+IOHMM_APPROX_REFERENCE: Final[PaperReference] = reference(
+    "§4", "side-information / IOHMM approximation"
+)
+
+
+@dataclass(frozen=True)
+class BucketedTransitionConfig:
+    """Parameter bundle for the bucketed transition model.
+
+    ``n_buckets`` is the number of side-information intervals (>= 2).
+    ``smoothing`` is the additive prior weight toward the baseline matrix;
+    empty rows in any bucket fall back exactly to the baseline when
+    ``smoothing > 0``.
+    ``grid_size`` is reserved for use by ``bucket_boundaries_from_spline_grid``
+    when deriving evaluation-grid boundaries from a spline predictor.
+
+    References: §4 side-information / IOHMM approximation
+    """
+
+    n_buckets: int = 3
+    smoothing: float = 1.0
+    grid_size: int = 200
+
+    def __post_init__(self) -> None:
+        if self.n_buckets < 2:
+            raise ValueError(f"n_buckets must be at least 2, got {self.n_buckets}.")
+        if self.smoothing <= 0.0:
+            raise ValueError(f"smoothing must be positive, got {self.smoothing}.")
+        if self.grid_size < 2:
+            raise ValueError(f"grid_size must be at least 2, got {self.grid_size}.")
+
+
+@dataclass(frozen=True)
+class BucketedTransitionResult:
+    """Fitted bucketed transition model.
+
+    ``bucket_boundaries`` holds the n_buckets - 1 interior split points.
+    ``transition_matrices`` has shape (n_buckets, K, K); every row sums to 1.
+    ``baseline_transition_matrix`` is the pooled (or caller-supplied) K × K
+    matrix used as the smoothing prior; empty bucket rows fall back to it.
+    ``bucket_observation_counts`` counts raw transitions assigned to each bucket
+    (before smoothing).
+
+    References: §4 side-information / IOHMM approximation
+    """
+
+    config: BucketedTransitionConfig
+    bucket_boundaries: np.ndarray  # shape (n_buckets - 1,)
+    transition_matrices: np.ndarray  # shape (n_buckets, K, K)
+    baseline_transition_matrix: np.ndarray  # shape (K, K)
+    bucket_observation_counts: np.ndarray  # shape (n_buckets,), raw transition counts
+
+    def __post_init__(self) -> None:
+        n_buckets = self.config.n_buckets
+
+        boundaries = np.asarray(self.bucket_boundaries, dtype=float).copy()
+        matrices = np.asarray(self.transition_matrices, dtype=float).copy()
+        baseline = np.asarray(self.baseline_transition_matrix, dtype=float).copy()
+        counts = np.asarray(self.bucket_observation_counts, dtype=int).copy()
+
+        if boundaries.ndim != 1 or len(boundaries) != n_buckets - 1:
+            raise ValueError(
+                f"bucket_boundaries must have shape ({n_buckets - 1},) for "
+                f"n_buckets={n_buckets}; got {boundaries.shape}."
+            )
+        if (
+            matrices.ndim != 3
+            or matrices.shape[0] != n_buckets
+            or matrices.shape[1] != matrices.shape[2]
+        ):
+            raise ValueError(
+                f"transition_matrices must have shape ({n_buckets}, K, K); "
+                f"got {matrices.shape}."
+            )
+        K = matrices.shape[1]
+        if baseline.shape != (K, K):
+            raise ValueError(
+                f"baseline_transition_matrix must have shape ({K}, {K}); "
+                f"got {baseline.shape}."
+            )
+        if counts.shape != (n_buckets,):
+            raise ValueError(
+                f"bucket_observation_counts must have shape ({n_buckets},); "
+                f"got {counts.shape}."
+            )
+
+        boundaries.setflags(write=False)
+        matrices.setflags(write=False)
+        baseline.setflags(write=False)
+        counts.setflags(write=False)
+
+        object.__setattr__(self, "bucket_boundaries", boundaries)
+        object.__setattr__(self, "transition_matrices", matrices)
+        object.__setattr__(self, "baseline_transition_matrix", baseline)
+        object.__setattr__(self, "bucket_observation_counts", counts)
+
+    def bucket_index_for(self, x: float) -> int:
+        """Return the bucket index (0-based) for side-information value ``x``."""
+        return int(np.searchsorted(self.bucket_boundaries, x, side="right"))
+
+    def transition_matrix_for(self, x: float) -> np.ndarray:
+        """Return the K × K transition matrix for side-information value ``x``."""
+        return cast(np.ndarray, self.transition_matrices[self.bucket_index_for(x)])
+
+
+def fit_bucketed_transition_model(
+    state_sequence: np.ndarray,
+    side_information: np.ndarray,
+    *,
+    n_states: int | None = None,
+    baseline_transition_matrix: np.ndarray | None = None,
+    bucket_boundaries: np.ndarray | None = None,
+    config: BucketedTransitionConfig | None = None,
+) -> BucketedTransitionResult:
+    """Estimate one transition matrix per side-information bucket.
+
+    ``state_sequence`` is a 1-D integer array of length T.  ``side_information``
+    is a 1-D finite float array of the same length T.  For each consecutive pair
+    (s_t, s_{t+1}), the transition is assigned to the bucket determined by x_t.
+
+    ``n_states`` overrides the inferred state-space size; must be >= 2.
+    ``baseline_transition_matrix`` is used as the smoothing prior; if omitted it
+    is estimated from pooled counts across all buckets.
+    ``bucket_boundaries`` are the n_buckets - 1 interior split points; if omitted
+    they are derived from quantiles of the side-information values over the
+    transition indices.
+
+    References: §4 side-information / IOHMM approximation
+    """
+    if config is None:
+        config = BucketedTransitionConfig()
+
+    states = _coerce_state_sequence(state_sequence)
+    x = _coerce_side_information(side_information, len(states))
+    K = _resolve_n_states(states, n_states)
+    n_buckets = config.n_buckets
+
+    # x_t and transition pairs use indices 0 .. T-2
+    x_t = x[:-1]
+    s_from = states[:-1]
+    s_to = states[1:]
+
+    resolved_boundaries = _resolve_bucket_boundaries(x_t, bucket_boundaries, n_buckets)
+
+    # Raw transition counts per bucket
+    raw_counts = np.zeros((n_buckets, K, K), dtype=float)
+    bucket_indices = np.searchsorted(resolved_boundaries, x_t, side="right")
+    for t_idx in range(len(s_from)):
+        raw_counts[bucket_indices[t_idx], s_from[t_idx], s_to[t_idx]] += 1.0
+
+    if baseline_transition_matrix is not None:
+        baseline = _validate_baseline(baseline_transition_matrix, K)
+    else:
+        baseline = _estimate_baseline(raw_counts, K)
+
+    transition_matrices = _smooth_and_normalize(raw_counts, baseline, config.smoothing)
+    bucket_obs_counts = raw_counts.sum(axis=(1, 2)).astype(int)
+
+    return BucketedTransitionResult(
+        config=config,
+        bucket_boundaries=resolved_boundaries,
+        transition_matrices=transition_matrices,
+        baseline_transition_matrix=baseline,
+        bucket_observation_counts=bucket_obs_counts,
+    )
+
+
+def bucket_boundaries_from_spline_grid(
+    spline_result: SplinePredictorResult,
+    *,
+    config: BucketedTransitionConfig | None = None,
+) -> np.ndarray:
+    """Derive deterministic bucket boundaries from a fitted spline predictor.
+
+    Places n_buckets - 1 equally-spaced interior boundaries across the spline's
+    observed support [x_min, x_max].  This is a deterministic approximation
+    that partitions the feature space uniformly; callers may pass the result
+    directly as ``bucket_boundaries`` to ``fit_bucketed_transition_model``.
+
+    References: §4 side-information / IOHMM approximation
+    """
+    if config is None:
+        config = BucketedTransitionConfig()
+    endpoints = np.linspace(spline_result.x_min, spline_result.x_max, config.n_buckets + 1)
+    return endpoints[1:-1]
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+def _coerce_state_sequence(seq: np.ndarray) -> np.ndarray:
+    try:
+        states = np.asarray(seq, dtype=int)
+    except (ValueError, TypeError) as exc:
+        raise ValueError(
+            f"state_sequence must be integer-like; got {type(seq).__name__}."
+        ) from exc
+    if states.ndim != 1:
+        raise ValueError(
+            f"state_sequence must be one-dimensional, got shape {states.shape}."
+        )
+    if len(states) < 2:
+        raise ValueError(
+            f"state_sequence must have at least 2 observations to form a transition; "
+            f"got {len(states)}."
+        )
+    if np.any(states < 0):
+        raise ValueError("state_sequence must contain only non-negative state indices.")
+    return states
+
+
+def _coerce_side_information(x: np.ndarray, expected_length: int) -> np.ndarray:
+    values = np.asarray(x, dtype=float)
+    if values.ndim != 1:
+        raise ValueError(
+            f"side_information must be one-dimensional, got shape {values.shape}."
+        )
+    if len(values) != expected_length:
+        raise ValueError(
+            f"side_information must have the same length as state_sequence; "
+            f"got {len(values)}, expected {expected_length}."
+        )
+    if not np.all(np.isfinite(values)):
+        n_invalid = int(np.sum(~np.isfinite(values)))
+        raise ValueError(
+            f"side_information must contain only finite values; "
+            f"found {n_invalid} non-finite value(s)."
+        )
+    return values
+
+
+def _resolve_n_states(states: np.ndarray, n_states: int | None) -> int:
+    inferred = int(states.max()) + 1
+    if n_states is not None:
+        if n_states < 2:
+            raise ValueError(f"n_states must be at least 2, got {n_states}.")
+        if inferred > n_states:
+            raise ValueError(
+                f"state_sequence contains state index {inferred - 1} "
+                f"but n_states={n_states}; all states must be in [0, n_states - 1]."
+            )
+        return n_states
+    if inferred < 2:
+        raise ValueError(
+            f"At least 2 states are required; inferred K={inferred} from state_sequence. "
+            "Pass n_states explicitly or include at least 2 distinct states."
+        )
+    return inferred
+
+
+def _resolve_bucket_boundaries(
+    x: np.ndarray,
+    provided: np.ndarray | None,
+    n_buckets: int,
+) -> np.ndarray:
+    if provided is not None:
+        b = np.asarray(provided, dtype=float)
+        if b.ndim != 1:
+            raise ValueError("bucket_boundaries must be one-dimensional.")
+        if len(b) != n_buckets - 1:
+            raise ValueError(
+                f"bucket_boundaries must have {n_buckets - 1} interior value(s) for "
+                f"n_buckets={n_buckets}; got {len(b)}."
+            )
+        if not np.all(np.isfinite(b)):
+            raise ValueError("bucket_boundaries must contain only finite values.")
+        if n_buckets > 2 and not np.all(b[:-1] < b[1:]):
+            raise ValueError("bucket_boundaries must be strictly increasing.")
+        return b.copy()
+
+    # Quantile-based boundaries; fall back to linspace if duplicates arise
+    levels = np.linspace(0.0, 1.0, n_buckets + 1)[1:-1]
+    boundaries = np.quantile(x, levels)
+    if len(np.unique(boundaries)) < len(boundaries):
+        lo, hi = float(x.min()), float(x.max())
+        if np.isclose(lo, hi):
+            lo, hi = lo - 1e-10, hi + 1e-10
+        boundaries = np.linspace(lo, hi, n_buckets + 1)[1:-1]
+    return cast(np.ndarray, boundaries)
+
+
+def _estimate_baseline(raw_counts: np.ndarray, K: int) -> np.ndarray:
+    pooled = raw_counts.sum(axis=0)  # (K, K)
+    row_sums = pooled.sum(axis=1, keepdims=True)
+    uniform = np.ones((1, K), dtype=float) / K
+    with np.errstate(invalid="ignore", divide="ignore"):
+        baseline = np.where(row_sums == 0, uniform, pooled / np.where(row_sums == 0, 1.0, row_sums))
+    return baseline
+
+
+def _validate_baseline(matrix: np.ndarray, K: int) -> np.ndarray:
+    b = np.asarray(matrix, dtype=float)
+    if b.shape != (K, K):
+        raise ValueError(
+            f"baseline_transition_matrix must have shape ({K}, {K}), got {b.shape}."
+        )
+    if not np.all(np.isfinite(b)):
+        raise ValueError("baseline_transition_matrix must contain only finite values.")
+    if not np.all(b >= 0):
+        raise ValueError("baseline_transition_matrix must have nonnegative entries.")
+    row_sums = b.sum(axis=1)
+    if not np.allclose(row_sums, 1.0, atol=1e-6):
+        raise ValueError(
+            "baseline_transition_matrix rows must each sum to 1.0 within tolerance; "
+            f"got row sums: {row_sums.tolist()}."
+        )
+    return b.copy()
+
+
+def _smooth_and_normalize(
+    raw_counts: np.ndarray,
+    baseline: np.ndarray,
+    smoothing: float,
+) -> np.ndarray:
+    # Broadcast baseline over bucket dimension: (n_buckets, K, K)
+    smoothed = raw_counts + smoothing * baseline[np.newaxis, :, :]
+    row_sums = smoothed.sum(axis=2, keepdims=True)
+    # row_sums > 0 is guaranteed: smoothing > 0 and baseline rows sum to 1
+    return cast(np.ndarray, smoothed / row_sums)

--- a/src/hft_hmm/models/iohmm_approx.py
+++ b/src/hft_hmm/models/iohmm_approx.py
@@ -98,7 +98,12 @@ class BucketedTransitionResult:
         boundaries = np.asarray(self.bucket_boundaries, dtype=float).copy()
         matrices = np.asarray(self.transition_matrices, dtype=float).copy()
         baseline = np.asarray(self.baseline_transition_matrix, dtype=float).copy()
-        counts = np.asarray(self.bucket_observation_counts, dtype=int).copy()
+        counts_raw = np.asarray(self.bucket_observation_counts)
+        if not np.all(np.isfinite(counts_raw)):
+            raise ValueError("bucket_observation_counts must contain only finite values.")
+        if not np.allclose(counts_raw, np.round(counts_raw)):
+            raise ValueError("bucket_observation_counts must contain only integer values.")
+        counts = counts_raw.astype(int).copy()
 
         if boundaries.ndim != 1 or len(boundaries) != n_buckets - 1:
             raise ValueError(

--- a/src/hft_hmm/models/iohmm_approx.py
+++ b/src/hft_hmm/models/iohmm_approx.py
@@ -58,10 +58,12 @@ class BucketedTransitionConfig:
     grid_size: int = 200
 
     def __post_init__(self) -> None:
+        _validate_int(self.n_buckets, "n_buckets")
         if self.n_buckets < 2:
             raise ValueError(f"n_buckets must be at least 2, got {self.n_buckets}.")
-        if self.smoothing <= 0.0:
+        if not np.isfinite(self.smoothing) or self.smoothing <= 0.0:
             raise ValueError(f"smoothing must be positive, got {self.smoothing}.")
+        _validate_int(self.grid_size, "grid_size")
         if self.grid_size < 2:
             raise ValueError(f"grid_size must be at least 2, got {self.grid_size}.")
 
@@ -87,6 +89,10 @@ class BucketedTransitionResult:
     bucket_observation_counts: np.ndarray  # shape (n_buckets,), raw transition counts
 
     def __post_init__(self) -> None:
+        if not isinstance(self.config, BucketedTransitionConfig):
+            raise TypeError(
+                "config must be a BucketedTransitionConfig, " f"got {type(self.config).__name__}."
+            )
         n_buckets = self.config.n_buckets
 
         boundaries = np.asarray(self.bucket_boundaries, dtype=float).copy()
@@ -99,6 +105,10 @@ class BucketedTransitionResult:
                 f"bucket_boundaries must have shape ({n_buckets - 1},) for "
                 f"n_buckets={n_buckets}; got {boundaries.shape}."
             )
+        if not np.all(np.isfinite(boundaries)):
+            raise ValueError("bucket_boundaries must contain only finite values.")
+        if len(boundaries) > 1 and not np.all(boundaries[:-1] < boundaries[1:]):
+            raise ValueError("bucket_boundaries must be strictly increasing.")
         if (
             matrices.ndim != 3
             or matrices.shape[0] != n_buckets
@@ -109,16 +119,25 @@ class BucketedTransitionResult:
                 f"got {matrices.shape}."
             )
         K = matrices.shape[1]
+        if K < 2:
+            raise ValueError(f"transition_matrices must use K >= 2, got K={K}.")
+        if not np.all(np.isfinite(matrices)):
+            raise ValueError("transition_matrices must contain only finite values.")
+        if not np.all(matrices >= 0.0):
+            raise ValueError("transition_matrices must have nonnegative entries.")
+        if not np.allclose(matrices.sum(axis=2), 1.0, atol=1e-10):
+            raise ValueError("transition_matrices rows must sum to 1.")
         if baseline.shape != (K, K):
             raise ValueError(
-                f"baseline_transition_matrix must have shape ({K}, {K}); "
-                f"got {baseline.shape}."
+                f"baseline_transition_matrix must have shape ({K}, {K}); " f"got {baseline.shape}."
             )
+        _validate_transition_matrix(baseline, "baseline_transition_matrix")
         if counts.shape != (n_buckets,):
             raise ValueError(
-                f"bucket_observation_counts must have shape ({n_buckets},); "
-                f"got {counts.shape}."
+                f"bucket_observation_counts must have shape ({n_buckets},); " f"got {counts.shape}."
             )
+        if not np.all(counts >= 0):
+            raise ValueError("bucket_observation_counts must be nonnegative.")
 
         boundaries.setflags(write=False)
         matrices.setflags(write=False)
@@ -132,7 +151,10 @@ class BucketedTransitionResult:
 
     def bucket_index_for(self, x: float) -> int:
         """Return the bucket index (0-based) for side-information value ``x``."""
-        return int(np.searchsorted(self.bucket_boundaries, x, side="right"))
+        value = float(x)
+        if not np.isfinite(value):
+            raise ValueError(f"x must be finite, got {x!r}.")
+        return int(np.searchsorted(self.bucket_boundaries, value, side="right"))
 
     def transition_matrix_for(self, x: float) -> np.ndarray:
         """Return the K × K transition matrix for side-information value ``x``."""
@@ -165,6 +187,8 @@ def fit_bucketed_transition_model(
     """
     if config is None:
         config = BucketedTransitionConfig()
+    elif not isinstance(config, BucketedTransitionConfig):
+        raise TypeError(f"config must be a BucketedTransitionConfig, got {type(config).__name__}.")
 
     states = _coerce_state_sequence(state_sequence)
     x = _coerce_side_information(side_information, len(states))
@@ -208,17 +232,36 @@ def bucket_boundaries_from_spline_grid(
 ) -> np.ndarray:
     """Derive deterministic bucket boundaries from a fitted spline predictor.
 
-    Places n_buckets - 1 equally-spaced interior boundaries across the spline's
-    observed support [x_min, x_max].  This is a deterministic approximation
-    that partitions the feature space uniformly; callers may pass the result
-    directly as ``bucket_boundaries`` to ``fit_bucketed_transition_model``.
+    Uses ``spline_result.evaluation_grid(config.grid_size)`` and places
+    n_buckets - 1 equally spaced interior boundaries across the evaluated
+    support. This is a deterministic approximation that partitions the feature
+    space uniformly; callers may pass the result directly as
+    ``bucket_boundaries`` to ``fit_bucketed_transition_model``.
 
     References: §4 side-information / IOHMM approximation
     """
     if config is None:
         config = BucketedTransitionConfig()
-    endpoints = np.linspace(spline_result.x_min, spline_result.x_max, config.n_buckets + 1)
-    return endpoints[1:-1]
+    elif not isinstance(config, BucketedTransitionConfig):
+        raise TypeError(f"config must be a BucketedTransitionConfig, got {type(config).__name__}.")
+
+    x_grid, _ = spline_result.evaluation_grid(config.grid_size)
+    grid = np.asarray(x_grid, dtype=float)
+    if grid.ndim != 1 or grid.shape[0] != config.grid_size:
+        raise ValueError(
+            "spline_result.evaluation_grid() must return a 1-D x grid with "
+            f"{config.grid_size} points; got shape {grid.shape}."
+        )
+    if not np.all(np.isfinite(grid)):
+        raise ValueError("spline evaluation grid must contain only finite x values.")
+    if not np.all(grid[:-1] < grid[1:]):
+        raise ValueError("spline evaluation grid x values must be strictly increasing.")
+
+    target_positions = np.linspace(0.0, config.grid_size - 1, config.n_buckets + 1)[1:-1]
+    return cast(
+        np.ndarray,
+        np.interp(target_positions, np.arange(config.grid_size, dtype=float), grid),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -228,20 +271,22 @@ def bucket_boundaries_from_spline_grid(
 
 def _coerce_state_sequence(seq: np.ndarray) -> np.ndarray:
     try:
-        states = np.asarray(seq, dtype=int)
+        raw = np.asarray(seq)
     except (ValueError, TypeError) as exc:
-        raise ValueError(
-            f"state_sequence must be integer-like; got {type(seq).__name__}."
-        ) from exc
-    if states.ndim != 1:
-        raise ValueError(
-            f"state_sequence must be one-dimensional, got shape {states.shape}."
-        )
-    if len(states) < 2:
+        raise ValueError(f"state_sequence must be integer-like; got {type(seq).__name__}.") from exc
+    if raw.ndim != 1:
+        raise ValueError(f"state_sequence must be one-dimensional, got shape {raw.shape}.")
+    if len(raw) < 2:
         raise ValueError(
             f"state_sequence must have at least 2 observations to form a transition; "
-            f"got {len(states)}."
+            f"got {len(raw)}."
         )
+    numeric = np.asarray(raw, dtype=float)
+    if not np.all(np.isfinite(numeric)):
+        raise ValueError("state_sequence must contain only finite state indices.")
+    if not np.all(np.equal(numeric, np.floor(numeric))):
+        raise ValueError("state_sequence must contain integer-valued state indices.")
+    states = numeric.astype(int)
     if np.any(states < 0):
         raise ValueError("state_sequence must contain only non-negative state indices.")
     return states
@@ -250,9 +295,7 @@ def _coerce_state_sequence(seq: np.ndarray) -> np.ndarray:
 def _coerce_side_information(x: np.ndarray, expected_length: int) -> np.ndarray:
     values = np.asarray(x, dtype=float)
     if values.ndim != 1:
-        raise ValueError(
-            f"side_information must be one-dimensional, got shape {values.shape}."
-        )
+        raise ValueError(f"side_information must be one-dimensional, got shape {values.shape}.")
     if len(values) != expected_length:
         raise ValueError(
             f"side_information must have the same length as state_sequence; "
@@ -270,6 +313,7 @@ def _coerce_side_information(x: np.ndarray, expected_length: int) -> np.ndarray:
 def _resolve_n_states(states: np.ndarray, n_states: int | None) -> int:
     inferred = int(states.max()) + 1
     if n_states is not None:
+        _validate_int(n_states, "n_states")
         if n_states < 2:
             raise ValueError(f"n_states must be at least 2, got {n_states}.")
         if inferred > n_states:
@@ -329,19 +373,8 @@ def _estimate_baseline(raw_counts: np.ndarray, K: int) -> np.ndarray:
 def _validate_baseline(matrix: np.ndarray, K: int) -> np.ndarray:
     b = np.asarray(matrix, dtype=float)
     if b.shape != (K, K):
-        raise ValueError(
-            f"baseline_transition_matrix must have shape ({K}, {K}), got {b.shape}."
-        )
-    if not np.all(np.isfinite(b)):
-        raise ValueError("baseline_transition_matrix must contain only finite values.")
-    if not np.all(b >= 0):
-        raise ValueError("baseline_transition_matrix must have nonnegative entries.")
-    row_sums = b.sum(axis=1)
-    if not np.allclose(row_sums, 1.0, atol=1e-6):
-        raise ValueError(
-            "baseline_transition_matrix rows must each sum to 1.0 within tolerance; "
-            f"got row sums: {row_sums.tolist()}."
-        )
+        raise ValueError(f"baseline_transition_matrix must have shape ({K}, {K}), got {b.shape}.")
+    _validate_transition_matrix(b, "baseline_transition_matrix", atol=1e-6)
     return b.copy()
 
 
@@ -355,3 +388,26 @@ def _smooth_and_normalize(
     row_sums = smoothed.sum(axis=2, keepdims=True)
     # row_sums > 0 is guaranteed: smoothing > 0 and baseline rows sum to 1
     return cast(np.ndarray, smoothed / row_sums)
+
+
+def _validate_int(value: int, name: str) -> None:
+    if not isinstance(value, (int, np.integer)) or isinstance(value, bool):
+        raise TypeError(f"{name} must be an integer, got {type(value).__name__}.")
+
+
+def _validate_transition_matrix(
+    matrix: np.ndarray,
+    name: str,
+    *,
+    atol: float = 1e-10,
+) -> None:
+    if not np.all(np.isfinite(matrix)):
+        raise ValueError(f"{name} must contain only finite values.")
+    if not np.all(matrix >= 0.0):
+        raise ValueError(f"{name} must have nonnegative entries.")
+    row_sums = matrix.sum(axis=1)
+    if not np.allclose(row_sums, 1.0, atol=atol):
+        raise ValueError(
+            f"{name} rows must each sum to 1.0 within tolerance; "
+            f"got row sums: {row_sums.tolist()}."
+        )

--- a/tests/test_iohmm_approx.py
+++ b/tests/test_iohmm_approx.py
@@ -10,6 +10,8 @@ import pytest
 from hft_hmm.core.references import ENGINEERING_APPROXIMATION, module_category
 from hft_hmm.models.iohmm_approx import (
     BucketedTransitionConfig,
+    BucketedTransitionResult,
+    bucket_boundaries_from_spline_grid,
     fit_bucketed_transition_model,
 )
 
@@ -69,16 +71,28 @@ def test_config_rejects_n_buckets_below_2() -> None:
         BucketedTransitionConfig(n_buckets=1)
 
 
+def test_config_rejects_non_integer_n_buckets() -> None:
+    with pytest.raises(TypeError, match="n_buckets must be an integer"):
+        BucketedTransitionConfig(n_buckets=2.5)  # type: ignore[arg-type]
+
+
 def test_config_rejects_nonpositive_smoothing() -> None:
     with pytest.raises(ValueError, match="smoothing must be positive"):
         BucketedTransitionConfig(smoothing=0.0)
     with pytest.raises(ValueError, match="smoothing must be positive"):
         BucketedTransitionConfig(smoothing=-1.0)
+    with pytest.raises(ValueError, match="smoothing must be positive"):
+        BucketedTransitionConfig(smoothing=float("nan"))
 
 
 def test_config_rejects_grid_size_below_2() -> None:
     with pytest.raises(ValueError, match="grid_size must be at least 2"):
         BucketedTransitionConfig(grid_size=1)
+
+
+def test_config_rejects_non_integer_grid_size() -> None:
+    with pytest.raises(TypeError, match="grid_size must be an integer"):
+        BucketedTransitionConfig(grid_size=2.5)  # type: ignore[arg-type]
 
 
 # ---------------------------------------------------------------------------
@@ -98,6 +112,36 @@ def test_result_arrays_are_read_only() -> None:
     result = fit_bucketed_transition_model(states, x)
     with pytest.raises(ValueError):
         result.transition_matrices[0, 0, 0] = 999.0
+
+
+def test_result_rejects_bad_transition_matrix_rows() -> None:
+    cfg = BucketedTransitionConfig(n_buckets=2)
+    with pytest.raises(ValueError, match="transition_matrices rows must sum to 1"):
+        BucketedTransitionResult(
+            config=cfg,
+            bucket_boundaries=np.array([0.5]),
+            transition_matrices=np.array(
+                [
+                    [[0.7, 0.7], [0.5, 0.5]],
+                    [[0.5, 0.5], [0.5, 0.5]],
+                ]
+            ),
+            baseline_transition_matrix=np.array([[0.5, 0.5], [0.5, 0.5]]),
+            bucket_observation_counts=np.array([1, 1]),
+        )
+
+
+def test_result_rejects_negative_bucket_counts() -> None:
+    cfg = BucketedTransitionConfig(n_buckets=2)
+    matrices = np.repeat(np.array([[[0.5, 0.5], [0.5, 0.5]]]), repeats=2, axis=0)
+    with pytest.raises(ValueError, match="bucket_observation_counts must be nonnegative"):
+        BucketedTransitionResult(
+            config=cfg,
+            bucket_boundaries=np.array([0.5]),
+            transition_matrices=matrices,
+            baseline_transition_matrix=np.array([[0.5, 0.5], [0.5, 0.5]]),
+            bucket_observation_counts=np.array([1, -1]),
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -136,6 +180,13 @@ def test_bucket_index_for_two_bucket_case() -> None:
     assert result.bucket_index_for(1.0) == 1
 
 
+def test_bucket_index_for_rejects_nonfinite_value() -> None:
+    states, x = _make_states_and_x()
+    result = fit_bucketed_transition_model(states, x)
+    with pytest.raises(ValueError, match="x must be finite"):
+        result.bucket_index_for(float("nan"))
+
+
 # ---------------------------------------------------------------------------
 # transition_matrix_for
 # ---------------------------------------------------------------------------
@@ -147,12 +198,8 @@ def test_transition_matrix_for_returns_correct_slice() -> None:
     result = fit_bucketed_transition_model(
         states, x, bucket_boundaries=boundaries, config=BucketedTransitionConfig(n_buckets=2)
     )
-    np.testing.assert_array_equal(
-        result.transition_matrix_for(0.2), result.transition_matrices[0]
-    )
-    np.testing.assert_array_equal(
-        result.transition_matrix_for(0.8), result.transition_matrices[1]
-    )
+    np.testing.assert_array_equal(result.transition_matrix_for(0.2), result.transition_matrices[0])
+    np.testing.assert_array_equal(result.transition_matrix_for(0.8), result.transition_matrices[1])
 
 
 def test_transition_matrix_for_differs_across_buckets_on_synthetic_fixture() -> None:
@@ -166,9 +213,9 @@ def test_transition_matrix_for_differs_across_buckets_on_synthetic_fixture() -> 
     # Low-x bucket: state 0 is sticky → A[0, 0, 0] should be notably higher than A[1, 0, 0]
     a_low = result.transition_matrix_for(0.2)
     a_high = result.transition_matrix_for(0.8)
-    assert a_low[0, 0] > a_high[0, 0], (
-        f"Expected A_low[0,0]={a_low[0,0]:.3f} > A_high[0,0]={a_high[0,0]:.3f}"
-    )
+    assert (
+        a_low[0, 0] > a_high[0, 0]
+    ), f"Expected A_low[0,0]={a_low[0,0]:.3f} > A_high[0,0]={a_high[0,0]:.3f}"
 
 
 # ---------------------------------------------------------------------------
@@ -261,7 +308,9 @@ def test_smoothing_strength_affects_sparse_bucket() -> None:
     x = np.concatenate([np.full(T - 2, 0.1), [0.9, 0.9]])  # nearly all in bucket 0
     boundaries = np.array([0.5])
     result_strong = fit_bucketed_transition_model(
-        states, x, bucket_boundaries=boundaries,
+        states,
+        x,
+        bucket_boundaries=boundaries,
         config=BucketedTransitionConfig(n_buckets=2, smoothing=1000.0),
     )
     # With extreme smoothing, bucket 1 (sparse) should be nearly identical to baseline
@@ -279,6 +328,13 @@ def test_invalid_n_states_raises() -> None:
     x = np.array([0.1, 0.2, 0.3, 0.4])
     with pytest.raises(ValueError, match="n_states must be at least 2"):
         fit_bucketed_transition_model(states, x, n_states=1)
+
+
+def test_non_integer_n_states_raises() -> None:
+    states = np.array([0, 1, 0, 1])
+    x = np.array([0.1, 0.2, 0.3, 0.4])
+    with pytest.raises(TypeError, match="n_states must be an integer"):
+        fit_bucketed_transition_model(states, x, n_states=2.5)  # type: ignore[arg-type]
 
 
 def test_state_sequence_out_of_range_raises() -> None:
@@ -299,6 +355,20 @@ def test_state_sequence_must_be_1d() -> None:
     states = np.array([[0, 1], [0, 1]])
     x = np.array([0.1, 0.2, 0.3, 0.4])
     with pytest.raises(ValueError, match="one-dimensional"):
+        fit_bucketed_transition_model(states, x)
+
+
+def test_state_sequence_rejects_fractional_values() -> None:
+    states = np.array([0.0, 1.0, 1.2, 0.0])
+    x = np.array([0.1, 0.2, 0.3, 0.4])
+    with pytest.raises(ValueError, match="integer-valued"):
+        fit_bucketed_transition_model(states, x)
+
+
+def test_state_sequence_rejects_nonfinite_values() -> None:
+    states = np.array([0.0, 1.0, float("nan"), 0.0])
+    x = np.array([0.1, 0.2, 0.3, 0.4])
+    with pytest.raises(ValueError, match="finite"):
         fit_bucketed_transition_model(states, x)
 
 
@@ -333,7 +403,8 @@ def test_bad_boundaries_unsorted_raises() -> None:
     x = np.array([0.1, 0.5, 0.9, 0.3, 0.7])
     with pytest.raises(ValueError, match="strictly increasing"):
         fit_bucketed_transition_model(
-            states, x,
+            states,
+            x,
             bucket_boundaries=np.array([0.7, 0.3]),
             config=BucketedTransitionConfig(n_buckets=3),
         )
@@ -344,7 +415,8 @@ def test_bad_boundaries_wrong_length_raises() -> None:
     x = np.array([0.1, 0.5, 0.9, 0.3, 0.7])
     with pytest.raises(ValueError, match="interior value"):
         fit_bucketed_transition_model(
-            states, x,
+            states,
+            x,
             bucket_boundaries=np.array([0.5]),  # need 2 for n_buckets=3
             config=BucketedTransitionConfig(n_buckets=3),
         )
@@ -355,7 +427,8 @@ def test_bad_boundaries_nonfinite_raises() -> None:
     x = np.array([0.1, 0.5, 0.9, 0.3, 0.7])
     with pytest.raises(ValueError, match="finite"):
         fit_bucketed_transition_model(
-            states, x,
+            states,
+            x,
             bucket_boundaries=np.array([float("nan")]),
             config=BucketedTransitionConfig(n_buckets=2),
         )
@@ -390,7 +463,7 @@ def test_synthetic_two_bucket_fixture_produces_measurably_different_matrices() -
         bucket_boundaries=np.array([0.5]),
         config=BucketedTransitionConfig(n_buckets=2, smoothing=0.5),
     )
-    a_low = result.transition_matrices[0]   # x < 0.5: state 0 sticky
+    a_low = result.transition_matrices[0]  # x < 0.5: state 0 sticky
     a_high = result.transition_matrices[1]  # x >= 0.5: state 1 sticky
 
     # State 0 self-transition should be higher in the low-x bucket
@@ -398,9 +471,9 @@ def test_synthetic_two_bucket_fixture_produces_measurably_different_matrices() -
     # State 1 self-transition should be higher in the high-x bucket
     assert a_high[1, 1] > 0.7, f"A_high[1,1]={a_high[1,1]:.3f}"
     # Difference in A[0, 0, 0] should be substantial
-    assert a_low[0, 0] - a_high[0, 0] > 0.3, (
-        f"Expected gap > 0.3; got {a_low[0,0]:.3f} vs {a_high[0,0]:.3f}"
-    )
+    assert (
+        a_low[0, 0] - a_high[0, 0] > 0.3
+    ), f"Expected gap > 0.3; got {a_low[0,0]:.3f} vs {a_high[0,0]:.3f}"
 
 
 # ---------------------------------------------------------------------------
@@ -430,32 +503,55 @@ def test_custom_baseline_is_used_for_smoothing() -> None:
 
 
 def test_bucket_boundaries_from_spline_grid() -> None:
-    from unittest.mock import MagicMock
-
-    from hft_hmm.models.iohmm_approx import bucket_boundaries_from_spline_grid
-
-    spline = MagicMock()
-    spline.x_min = 0.0
-    spline.x_max = 1.0
+    class SplineStub:
+        def evaluation_grid(self, n: int) -> tuple[np.ndarray, np.ndarray]:
+            x_grid = np.linspace(0.0, 1.0, n)
+            return x_grid, np.zeros(n)
 
     cfg = BucketedTransitionConfig(n_buckets=3)
-    boundaries = bucket_boundaries_from_spline_grid(spline, config=cfg)
+    boundaries = bucket_boundaries_from_spline_grid(SplineStub(), config=cfg)
 
     assert boundaries.shape == (2,)  # n_buckets - 1
     np.testing.assert_allclose(boundaries, [1 / 3, 2 / 3], atol=1e-10)
 
 
 def test_bucket_boundaries_from_spline_grid_uses_default_config() -> None:
-    from unittest.mock import MagicMock
+    class SplineStub:
+        def evaluation_grid(self, n: int) -> tuple[np.ndarray, np.ndarray]:
+            x_grid = np.linspace(0.0, 3.0, n)
+            return x_grid, np.zeros(n)
 
-    from hft_hmm.models.iohmm_approx import bucket_boundaries_from_spline_grid
-
-    spline = MagicMock()
-    spline.x_min = 0.0
-    spline.x_max = 3.0
-
-    boundaries = bucket_boundaries_from_spline_grid(spline)
+    boundaries = bucket_boundaries_from_spline_grid(SplineStub())
     assert len(boundaries) == BucketedTransitionConfig().n_buckets - 1
+
+
+def test_bucket_boundaries_from_spline_grid_uses_config_grid_size() -> None:
+    class SplineStub:
+        def __init__(self) -> None:
+            self.received_n: int | None = None
+
+        def evaluation_grid(self, n: int) -> tuple[np.ndarray, np.ndarray]:
+            self.received_n = n
+            x_grid = np.linspace(0.0, 1.0, n)
+            return x_grid, np.zeros(n)
+
+    spline = SplineStub()
+    cfg = BucketedTransitionConfig(n_buckets=2, grid_size=17)
+
+    bucket_boundaries_from_spline_grid(spline, config=cfg)
+
+    assert spline.received_n == 17
+
+
+def test_bucket_boundaries_from_spline_grid_rejects_nonmonotone_grid() -> None:
+    class SplineStub:
+        def evaluation_grid(self, n: int) -> tuple[np.ndarray, np.ndarray]:
+            return np.array([0.0, 0.5, 0.5, 1.0]), np.zeros(n)
+
+    with pytest.raises(ValueError, match="strictly increasing"):
+        bucket_boundaries_from_spline_grid(
+            SplineStub(), config=BucketedTransitionConfig(n_buckets=2, grid_size=4)
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_iohmm_approx.py
+++ b/tests/test_iohmm_approx.py
@@ -1,0 +1,472 @@
+"""Tests for the bucketed IOHMM-style transition approximation."""
+
+from __future__ import annotations
+
+import importlib
+
+import numpy as np
+import pytest
+
+from hft_hmm.core.references import ENGINEERING_APPROXIMATION, module_category
+from hft_hmm.models.iohmm_approx import (
+    BucketedTransitionConfig,
+    fit_bucketed_transition_model,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_states_and_x(
+    T: int = 200,
+    n_states: int = 2,
+    seed: int = 0,
+) -> tuple[np.ndarray, np.ndarray]:
+    rng = np.random.default_rng(seed)
+    states = rng.integers(0, n_states, size=T)
+    x = rng.uniform(0.0, 1.0, size=T)
+    return states, x
+
+
+def _two_bucket_fixture(T: int = 600, seed: int = 42) -> tuple[np.ndarray, np.ndarray]:
+    """Synthetic fixture where x_t < 0.5 keeps state 0 sticky, x_t >= 0.5 keeps state 1 sticky."""
+    rng = np.random.default_rng(seed)
+    x = rng.uniform(0.0, 1.0, size=T)
+    states = np.zeros(T, dtype=int)
+    for t in range(T - 1):
+        if x[t] < 0.5:
+            states[t + 1] = 0 if rng.random() < 0.9 else 1
+        else:
+            states[t + 1] = 1 if rng.random() < 0.9 else 0
+    return states, x
+
+
+# ---------------------------------------------------------------------------
+# Taxonomy
+# ---------------------------------------------------------------------------
+
+
+def test_module_declares_engineering_approximation() -> None:
+    mod = importlib.import_module("hft_hmm.models.iohmm_approx")
+    assert module_category(mod) == ENGINEERING_APPROXIMATION
+
+
+# ---------------------------------------------------------------------------
+# Config validation
+# ---------------------------------------------------------------------------
+
+
+def test_config_defaults() -> None:
+    cfg = BucketedTransitionConfig()
+    assert cfg.n_buckets == 3
+    assert cfg.smoothing == 1.0
+    assert cfg.grid_size == 200
+
+
+def test_config_rejects_n_buckets_below_2() -> None:
+    with pytest.raises(ValueError, match="n_buckets must be at least 2"):
+        BucketedTransitionConfig(n_buckets=1)
+
+
+def test_config_rejects_nonpositive_smoothing() -> None:
+    with pytest.raises(ValueError, match="smoothing must be positive"):
+        BucketedTransitionConfig(smoothing=0.0)
+    with pytest.raises(ValueError, match="smoothing must be positive"):
+        BucketedTransitionConfig(smoothing=-1.0)
+
+
+def test_config_rejects_grid_size_below_2() -> None:
+    with pytest.raises(ValueError, match="grid_size must be at least 2"):
+        BucketedTransitionConfig(grid_size=1)
+
+
+# ---------------------------------------------------------------------------
+# Result immutability
+# ---------------------------------------------------------------------------
+
+
+def test_result_is_frozen() -> None:
+    states, x = _make_states_and_x()
+    result = fit_bucketed_transition_model(states, x, config=BucketedTransitionConfig(n_buckets=2))
+    with pytest.raises((AttributeError, TypeError)):
+        result.bucket_boundaries = np.array([0.5])  # type: ignore[misc]
+
+
+def test_result_arrays_are_read_only() -> None:
+    states, x = _make_states_and_x()
+    result = fit_bucketed_transition_model(states, x)
+    with pytest.raises(ValueError):
+        result.transition_matrices[0, 0, 0] = 999.0
+
+
+# ---------------------------------------------------------------------------
+# Bucket assignment determinism
+# ---------------------------------------------------------------------------
+
+
+def test_bucket_index_for_is_deterministic() -> None:
+    states, x = _make_states_and_x()
+    result = fit_bucketed_transition_model(states, x)
+    assert result.bucket_index_for(0.25) == result.bucket_index_for(0.25)
+
+
+def test_bucket_index_for_respects_boundaries() -> None:
+    states, x = _make_states_and_x()
+    boundaries = np.array([0.3, 0.7])
+    result = fit_bucketed_transition_model(
+        states, x, bucket_boundaries=boundaries, config=BucketedTransitionConfig(n_buckets=3)
+    )
+    assert result.bucket_index_for(0.0) == 0
+    assert result.bucket_index_for(0.3) == 1  # searchsorted side="right"
+    assert result.bucket_index_for(0.5) == 1
+    assert result.bucket_index_for(0.7) == 2
+    assert result.bucket_index_for(1.0) == 2
+
+
+def test_bucket_index_for_two_bucket_case() -> None:
+    states = np.array([0, 1, 0, 1, 0])
+    x = np.array([0.2, 0.8, 0.1, 0.9, 0.6])
+    result = fit_bucketed_transition_model(
+        states, x, bucket_boundaries=np.array([0.5]), config=BucketedTransitionConfig(n_buckets=2)
+    )
+    assert result.bucket_index_for(0.0) == 0
+    assert result.bucket_index_for(0.4999) == 0
+    assert result.bucket_index_for(0.5) == 1
+    assert result.bucket_index_for(1.0) == 1
+
+
+# ---------------------------------------------------------------------------
+# transition_matrix_for
+# ---------------------------------------------------------------------------
+
+
+def test_transition_matrix_for_returns_correct_slice() -> None:
+    states, x = _make_states_and_x()
+    boundaries = np.array([0.5])
+    result = fit_bucketed_transition_model(
+        states, x, bucket_boundaries=boundaries, config=BucketedTransitionConfig(n_buckets=2)
+    )
+    np.testing.assert_array_equal(
+        result.transition_matrix_for(0.2), result.transition_matrices[0]
+    )
+    np.testing.assert_array_equal(
+        result.transition_matrix_for(0.8), result.transition_matrices[1]
+    )
+
+
+def test_transition_matrix_for_differs_across_buckets_on_synthetic_fixture() -> None:
+    states, x = _two_bucket_fixture()
+    result = fit_bucketed_transition_model(
+        states,
+        x,
+        bucket_boundaries=np.array([0.5]),
+        config=BucketedTransitionConfig(n_buckets=2, smoothing=0.1),
+    )
+    # Low-x bucket: state 0 is sticky → A[0, 0, 0] should be notably higher than A[1, 0, 0]
+    a_low = result.transition_matrix_for(0.2)
+    a_high = result.transition_matrix_for(0.8)
+    assert a_low[0, 0] > a_high[0, 0], (
+        f"Expected A_low[0,0]={a_low[0,0]:.3f} > A_high[0,0]={a_high[0,0]:.3f}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Shape / finiteness / nonnegativity / row-sum invariants
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("n_buckets,n_states", [(2, 2), (3, 3), (4, 5)])
+def test_all_matrices_have_correct_shape(n_buckets: int, n_states: int) -> None:
+    states, x = _make_states_and_x(T=300, n_states=n_states)
+    result = fit_bucketed_transition_model(
+        states, x, config=BucketedTransitionConfig(n_buckets=n_buckets)
+    )
+    assert result.transition_matrices.shape == (n_buckets, n_states, n_states)
+
+
+@pytest.mark.parametrize("n_buckets", [2, 3, 5])
+def test_all_matrices_are_finite(n_buckets: int) -> None:
+    states, x = _make_states_and_x(T=300)
+    result = fit_bucketed_transition_model(
+        states, x, config=BucketedTransitionConfig(n_buckets=n_buckets)
+    )
+    assert np.all(np.isfinite(result.transition_matrices))
+
+
+@pytest.mark.parametrize("n_buckets", [2, 3, 5])
+def test_all_matrices_are_nonnegative(n_buckets: int) -> None:
+    states, x = _make_states_and_x(T=300)
+    result = fit_bucketed_transition_model(
+        states, x, config=BucketedTransitionConfig(n_buckets=n_buckets)
+    )
+    assert np.all(result.transition_matrices >= 0.0)
+
+
+@pytest.mark.parametrize("n_buckets", [2, 3, 5])
+def test_all_row_sums_are_one(n_buckets: int) -> None:
+    states, x = _make_states_and_x(T=300)
+    result = fit_bucketed_transition_model(
+        states, x, config=BucketedTransitionConfig(n_buckets=n_buckets)
+    )
+    row_sums = result.transition_matrices.sum(axis=2)
+    np.testing.assert_allclose(row_sums, 1.0, atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# Sparse / empty bucket smoothing
+# ---------------------------------------------------------------------------
+
+
+def test_empty_bucket_falls_back_to_baseline() -> None:
+    # All x_t values are concentrated in bucket 0; bucket 1 will be empty.
+    T = 100
+    states = np.zeros(T, dtype=int)
+    states[::2] = 1  # alternate 0,1,0,1,...
+    # Force all x values below 0.1 so bucket 0 gets everything
+    x = np.full(T, 0.05)
+    boundaries = np.array([0.5])
+    result = fit_bucketed_transition_model(
+        states, x, bucket_boundaries=boundaries, config=BucketedTransitionConfig(n_buckets=2)
+    )
+    assert result.bucket_observation_counts[1] == 0
+    np.testing.assert_allclose(
+        result.transition_matrices[1],
+        result.baseline_transition_matrix,
+        atol=1e-12,
+    )
+
+
+def test_sparse_bucket_smoothed_toward_baseline_stays_normalized() -> None:
+    # Bucket 1 gets only 1 observation; after smoothing it must still sum to 1.
+    states = np.array([0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0])
+    x = np.array([0.9, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1])
+    boundaries = np.array([0.5])
+    result = fit_bucketed_transition_model(
+        states, x, bucket_boundaries=boundaries, config=BucketedTransitionConfig(n_buckets=2)
+    )
+    # Bucket 0 has exactly 1 transition (x[0]=0.9 → bucket 1 index 1... wait)
+    # Actually x[0]=0.9 > 0.5 → bucket index 1, so bucket 1 gets that transition
+    # Bucket 0 gets all the remaining transitions where x < 0.5
+    row_sums = result.transition_matrices.sum(axis=2)
+    np.testing.assert_allclose(row_sums, 1.0, atol=1e-12)
+    assert np.all(np.isfinite(result.transition_matrices))
+
+
+def test_smoothing_strength_affects_sparse_bucket() -> None:
+    # With very high smoothing, sparse bucket should be very close to baseline.
+    T = 200
+    states = np.zeros(T, dtype=int)
+    states[::3] = 1
+    x = np.concatenate([np.full(T - 2, 0.1), [0.9, 0.9]])  # nearly all in bucket 0
+    boundaries = np.array([0.5])
+    result_strong = fit_bucketed_transition_model(
+        states, x, bucket_boundaries=boundaries,
+        config=BucketedTransitionConfig(n_buckets=2, smoothing=1000.0),
+    )
+    # With extreme smoothing, bucket 1 (sparse) should be nearly identical to baseline
+    diff = np.abs(result_strong.transition_matrices[1] - result_strong.baseline_transition_matrix)
+    assert diff.max() < 0.05
+
+
+# ---------------------------------------------------------------------------
+# Validation errors
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_n_states_raises() -> None:
+    states = np.array([0, 1, 0, 1])
+    x = np.array([0.1, 0.2, 0.3, 0.4])
+    with pytest.raises(ValueError, match="n_states must be at least 2"):
+        fit_bucketed_transition_model(states, x, n_states=1)
+
+
+def test_state_sequence_out_of_range_raises() -> None:
+    states = np.array([0, 1, 5, 0])  # state 5 but n_states=3
+    x = np.array([0.1, 0.2, 0.3, 0.4])
+    with pytest.raises(ValueError, match="state index"):
+        fit_bucketed_transition_model(states, x, n_states=3)
+
+
+def test_inferred_k_below_2_raises() -> None:
+    states = np.array([0, 0, 0, 0])  # all zeros → K=1
+    x = np.array([0.1, 0.2, 0.3, 0.4])
+    with pytest.raises(ValueError, match="At least 2 states"):
+        fit_bucketed_transition_model(states, x)
+
+
+def test_state_sequence_must_be_1d() -> None:
+    states = np.array([[0, 1], [0, 1]])
+    x = np.array([0.1, 0.2, 0.3, 0.4])
+    with pytest.raises(ValueError, match="one-dimensional"):
+        fit_bucketed_transition_model(states, x)
+
+
+def test_state_sequence_too_short_raises() -> None:
+    with pytest.raises(ValueError, match="at least 2"):
+        fit_bucketed_transition_model(np.array([0]), np.array([0.5]))
+
+
+def test_side_information_length_mismatch_raises() -> None:
+    states = np.array([0, 1, 0, 1])
+    x = np.array([0.1, 0.2, 0.3])
+    with pytest.raises(ValueError, match="same length"):
+        fit_bucketed_transition_model(states, x)
+
+
+def test_side_information_with_nan_raises() -> None:
+    states = np.array([0, 1, 0, 1])
+    x = np.array([0.1, float("nan"), 0.3, 0.4])
+    with pytest.raises(ValueError, match="non-finite"):
+        fit_bucketed_transition_model(states, x)
+
+
+def test_side_information_with_inf_raises() -> None:
+    states = np.array([0, 1, 0, 1])
+    x = np.array([0.1, float("inf"), 0.3, 0.4])
+    with pytest.raises(ValueError, match="non-finite"):
+        fit_bucketed_transition_model(states, x)
+
+
+def test_bad_boundaries_unsorted_raises() -> None:
+    states = np.array([0, 1, 0, 1, 0])
+    x = np.array([0.1, 0.5, 0.9, 0.3, 0.7])
+    with pytest.raises(ValueError, match="strictly increasing"):
+        fit_bucketed_transition_model(
+            states, x,
+            bucket_boundaries=np.array([0.7, 0.3]),
+            config=BucketedTransitionConfig(n_buckets=3),
+        )
+
+
+def test_bad_boundaries_wrong_length_raises() -> None:
+    states = np.array([0, 1, 0, 1, 0])
+    x = np.array([0.1, 0.5, 0.9, 0.3, 0.7])
+    with pytest.raises(ValueError, match="interior value"):
+        fit_bucketed_transition_model(
+            states, x,
+            bucket_boundaries=np.array([0.5]),  # need 2 for n_buckets=3
+            config=BucketedTransitionConfig(n_buckets=3),
+        )
+
+
+def test_bad_boundaries_nonfinite_raises() -> None:
+    states = np.array([0, 1, 0, 1, 0])
+    x = np.array([0.1, 0.5, 0.9, 0.3, 0.7])
+    with pytest.raises(ValueError, match="finite"):
+        fit_bucketed_transition_model(
+            states, x,
+            bucket_boundaries=np.array([float("nan")]),
+            config=BucketedTransitionConfig(n_buckets=2),
+        )
+
+
+def test_invalid_baseline_wrong_shape_raises() -> None:
+    states = np.array([0, 1, 0, 1, 0])
+    x = np.array([0.1, 0.5, 0.9, 0.3, 0.7])
+    bad_baseline = np.eye(3)  # wrong shape for K=2
+    with pytest.raises(ValueError, match="shape"):
+        fit_bucketed_transition_model(states, x, baseline_transition_matrix=bad_baseline)
+
+
+def test_invalid_baseline_rows_not_summing_raises() -> None:
+    states = np.array([0, 1, 0, 1, 0])
+    x = np.array([0.1, 0.5, 0.9, 0.3, 0.7])
+    bad_baseline = np.array([[0.6, 0.6], [0.5, 0.5]])  # rows sum to 1.2
+    with pytest.raises(ValueError, match="sum to 1"):
+        fit_bucketed_transition_model(states, x, baseline_transition_matrix=bad_baseline)
+
+
+# ---------------------------------------------------------------------------
+# Synthetic two-bucket fixture — main functional test
+# ---------------------------------------------------------------------------
+
+
+def test_synthetic_two_bucket_fixture_produces_measurably_different_matrices() -> None:
+    states, x = _two_bucket_fixture(T=1000, seed=42)
+    result = fit_bucketed_transition_model(
+        states,
+        x,
+        bucket_boundaries=np.array([0.5]),
+        config=BucketedTransitionConfig(n_buckets=2, smoothing=0.5),
+    )
+    a_low = result.transition_matrices[0]   # x < 0.5: state 0 sticky
+    a_high = result.transition_matrices[1]  # x >= 0.5: state 1 sticky
+
+    # State 0 self-transition should be higher in the low-x bucket
+    assert a_low[0, 0] > 0.7, f"A_low[0,0]={a_low[0,0]:.3f}"
+    # State 1 self-transition should be higher in the high-x bucket
+    assert a_high[1, 1] > 0.7, f"A_high[1,1]={a_high[1,1]:.3f}"
+    # Difference in A[0, 0, 0] should be substantial
+    assert a_low[0, 0] - a_high[0, 0] > 0.3, (
+        f"Expected gap > 0.3; got {a_low[0,0]:.3f} vs {a_high[0,0]:.3f}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Provided baseline round-trips
+# ---------------------------------------------------------------------------
+
+
+def test_custom_baseline_is_used_for_smoothing() -> None:
+    states = np.array([0, 1, 0, 1, 0, 1, 0])
+    x = np.full(7, 0.9)  # all in bucket 1, bucket 0 is empty
+    uniform_baseline = np.array([[0.5, 0.5], [0.5, 0.5]])
+    result = fit_bucketed_transition_model(
+        states,
+        x,
+        bucket_boundaries=np.array([0.5]),
+        baseline_transition_matrix=uniform_baseline,
+        config=BucketedTransitionConfig(n_buckets=2),
+    )
+    # Bucket 0 is empty → must equal the provided baseline
+    np.testing.assert_allclose(result.transition_matrices[0], uniform_baseline, atol=1e-12)
+    np.testing.assert_allclose(result.baseline_transition_matrix, uniform_baseline, atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# bucket_boundaries_from_spline_grid helper
+# ---------------------------------------------------------------------------
+
+
+def test_bucket_boundaries_from_spline_grid() -> None:
+    from unittest.mock import MagicMock
+
+    from hft_hmm.models.iohmm_approx import bucket_boundaries_from_spline_grid
+
+    spline = MagicMock()
+    spline.x_min = 0.0
+    spline.x_max = 1.0
+
+    cfg = BucketedTransitionConfig(n_buckets=3)
+    boundaries = bucket_boundaries_from_spline_grid(spline, config=cfg)
+
+    assert boundaries.shape == (2,)  # n_buckets - 1
+    np.testing.assert_allclose(boundaries, [1 / 3, 2 / 3], atol=1e-10)
+
+
+def test_bucket_boundaries_from_spline_grid_uses_default_config() -> None:
+    from unittest.mock import MagicMock
+
+    from hft_hmm.models.iohmm_approx import bucket_boundaries_from_spline_grid
+
+    spline = MagicMock()
+    spline.x_min = 0.0
+    spline.x_max = 3.0
+
+    boundaries = bucket_boundaries_from_spline_grid(spline)
+    assert len(boundaries) == BucketedTransitionConfig().n_buckets - 1
+
+
+# ---------------------------------------------------------------------------
+# __init__.py re-exports
+# ---------------------------------------------------------------------------
+
+
+def test_exports_available_from_models_package() -> None:
+    import hft_hmm.models as models
+
+    assert hasattr(models, "BucketedTransitionConfig")
+    assert hasattr(models, "BucketedTransitionResult")
+    assert hasattr(models, "fit_bucketed_transition_model")
+    assert hasattr(models, "iohmm_approx")


### PR DESCRIPTION
Closes #36

## Summary
- Add a bucketed transition-matrix approximation for side-information-conditioned HMM transitions.
- Estimate one row-stochastic K x K transition matrix per side-information bucket with smoothing toward a baseline matrix.
- Add deterministic spline-grid boundary helper and package exports.
- Harden validation for config values, state sequences, lookup inputs, and result invariants.

## Checks
- .venv/bin/python -m pytest -q tests/test_iohmm_approx.py
- .venv/bin/python -m pytest -q
- .venv/bin/python -m ruff check .
- .venv/bin/python -m mypy src

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced bucketed IOHMM transition approximation models with configurable bucket boundaries and smoothing parameters.
  * Added new model-building functions for computing transition matrices from bucketed data.
  * Exported configuration classes and utility functions from the models package for easier access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->