### PR TITLE
feat(42): add quantile boundary mode for bucketed IOHMM transitions

### DIFF
--- a/GITHUB_ISSUES.md
+++ b/GITHUB_ISSUES.md
@@ -644,6 +644,57 @@ ML/DL inference engine outside the paper) must be reflected here as an
 
 ---
 
+## Issue 42 — Quantile boundary mode for bucketed IOHMM transitions
+**Branch:** `feat/42-quantile-boundary-mode`
+**Gate:** H
+
+### Goal
+Add an optional quantile-based boundary mode to the Issue 16 bucketed
+transition approximation so side-information features with tightly clustered
+support — notably the volatility ratio near 1.0 — can produce balanced bucket
+counts. The current `grid` mode spaces boundaries evenly across the spline
+support, which under-fills outer buckets when the feature distribution is
+heavy-tailed or concentrated.
+
+This is also the fair-baseline prerequisite for the planned HMC IOHMM
+extension tracked in `docs/dmm_mcmc_roadmap.md` (local, untracked): without
+quantile boundaries, part of any HMC win would be attributable to bucket
+imbalance rather than continuous-parametric conditioning. Issue 42 unlocks a
+three-way ablation (grid / quantile / HMC) for the planned MCMC extension.
+
+### Tasks
+- extend `BucketedTransitionConfig` with a `boundary_mode` field
+  (`"grid"` for current behavior, `"quantile"` for balanced empirical
+  buckets); default remains `"grid"` for backward compatibility
+- implement quantile-boundary computation from finite training
+  side-information values, with deterministic handling of duplicate
+  quantile values (e.g., when the feature is highly discrete)
+- preserve strict row normalization and the existing sparse-bucket
+  smoothing-toward-baseline behavior under both modes
+- degrade gracefully to `grid` when the empirical distribution has too
+  few unique values to define `R` quantile boundaries
+- surface `boundary_mode` in the bucket-observation-count logging so
+  the Issue 17 run artifacts remain inspectable post-hoc
+
+### Deliverables
+- updated `src/hft_hmm/models/iohmm_approx.py`
+- new tests in `tests/test_iohmm_approx.py`:
+  - deterministic quantile boundaries on a fixed feature distribution
+  - duplicate-quantile handling (feature with mass at a single value)
+  - sparse-feature graceful degradation
+  - backward compatibility of the existing `grid` mode (unchanged behavior)
+
+### Out of scope
+- changing Issue 17 artifacts or rerunning Gate H results
+- removing smoothing toward baseline
+- adding new side-information predictors
+
+### Acceptance notes
+See Gate H. Default behavior is preserved; the new mode is opt-in. Tracked
+at GitHub Issue #42 (follow-up from Issue 17 review).
+
+---
+
 ## Issue 24 — Paper-comparison results document
 **Branch:** `feat/24-results-vs-paper`
 **Gate:** J

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -233,7 +233,7 @@ A gate passes only when all listed conditions are satisfied.
 ---
 
 ## Gate H — IOHMM-style transition conditioning
-**Covers:** Issues 16, 17
+**Covers:** Issues 16, 17, 42
 
 ### Must pass
 - The repo contains a clearly labeled **approximate** transition-conditioning implementation following the paper's spline-bucketed approach (discretize each spline into buckets using its roots as boundaries; train a separate transition matrix per bucket).

--- a/src/hft_hmm/experiments/side_info_comparison.py
+++ b/src/hft_hmm/experiments/side_info_comparison.py
@@ -81,6 +81,7 @@ from hft_hmm.features.volatility_ratio import VolatilityRatioConfig, volatility_
 from hft_hmm.inference import filter_from_result
 from hft_hmm.models.gaussian_hmm import GaussianHMMResult, GaussianHMMWrapper
 from hft_hmm.models.iohmm_approx import (
+    BoundaryMode,
     BucketedTransitionConfig,
     BucketedTransitionResult,
     bucket_boundaries_from_quantiles,
@@ -759,7 +760,7 @@ def _bucket_boundaries_for_mode(
     spline_result: SplinePredictorResult,
     training_values: np.ndarray,
     config: BucketedTransitionConfig,
-) -> tuple[np.ndarray, str]:
+) -> tuple[np.ndarray, BoundaryMode]:
     """Resolve bucket boundaries and return the effective boundary mode."""
     if config.boundary_mode == "grid":
         return bucket_boundaries_from_spline_grid(spline_result, config=config), "grid"

--- a/src/hft_hmm/experiments/side_info_comparison.py
+++ b/src/hft_hmm/experiments/side_info_comparison.py
@@ -36,7 +36,7 @@ import os
 import shutil
 import tempfile
 import uuid
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any, Final
 
@@ -72,13 +72,18 @@ from hft_hmm.experiments.walk_forward import (
     walk_forward,
 )
 from hft_hmm.features.seasonality import SeasonalityConfig, intraday_seasonality
-from hft_hmm.features.splines import SplinePredictorConfig, fit_spline_predictor
+from hft_hmm.features.splines import (
+    SplinePredictorConfig,
+    SplinePredictorResult,
+    fit_spline_predictor,
+)
 from hft_hmm.features.volatility_ratio import VolatilityRatioConfig, volatility_ratio
 from hft_hmm.inference import filter_from_result
 from hft_hmm.models.gaussian_hmm import GaussianHMMResult, GaussianHMMWrapper
 from hft_hmm.models.iohmm_approx import (
     BucketedTransitionConfig,
     BucketedTransitionResult,
+    bucket_boundaries_from_quantiles,
     bucket_boundaries_from_spline_grid,
     fit_bucketed_transition_model,
 )
@@ -221,6 +226,7 @@ class SideInfoComparisonConfig:
         assert retrain_every_days is not None  # normalized in WalkForwardConfig.__post_init__
         return {
             "bucketed_transition": {
+                "boundary_mode": self.bucketed_transition.boundary_mode,
                 "grid_size": int(self.bucketed_transition.grid_size),
                 "n_buckets": int(self.bucketed_transition.n_buckets),
                 "smoothing": float(self.bucketed_transition.smoothing),
@@ -299,6 +305,7 @@ class SideInfoComparisonConfig:
             n_buckets=int(bt_raw.get("n_buckets", 3)),
             smoothing=float(bt_raw.get("smoothing", 1.0)),
             grid_size=int(bt_raw.get("grid_size", 200)),
+            boundary_mode=bt_raw.get("boundary_mode", "grid"),
         )
         vr_raw = raw.get("vol_ratio", {})
         vol_ratio_cfg = VolatilityRatioConfig(
@@ -371,6 +378,7 @@ class SideInfoVariantWindow:
     n_train_obs: int
     n_forecast_obs: int
     bucket_observation_counts: tuple[int, ...]
+    boundary_mode: str
     summary: pd.DataFrame
 
     def __post_init__(self) -> None:
@@ -392,6 +400,10 @@ class SideInfoVariantWindow:
             raise ValueError(
                 "forecast_start must be strictly after train_end; "
                 f"got train_end={self.train_end} forecast_start={self.forecast_start}."
+            )
+        if self.boundary_mode not in ("grid", "quantile"):
+            raise ValueError(
+                "boundary_mode must be one of ('grid', 'quantile'), " f"got {self.boundary_mode!r}."
             )
         if not isinstance(self.summary, pd.DataFrame):
             raise TypeError("summary must be a pd.DataFrame.")
@@ -633,17 +645,21 @@ def _run_side_info_variant(
                 "fully initialized before the forecast slice."
             )
 
-        spline_result = fit_spline_predictor(feature_train, train_slice, config=config.spline)
-        boundaries = bucket_boundaries_from_spline_grid(
-            spline_result, config=config.bucketed_transition
-        )
-
         feature_train_clean = feature_train.dropna()
         if feature_train_clean.shape[0] < 2:
             raise ValueError(
                 f"variant {variant!r} window {baseline_window.index} has fewer than 2 "
                 "finite training feature observations after dropping the NaN prefix."
             )
+        spline_result = fit_spline_predictor(feature_train, train_slice, config=config.spline)
+        boundaries, boundary_mode = _bucket_boundaries_for_mode(
+            spline_result=spline_result,
+            training_values=feature_train_clean.to_numpy(),
+            config=config.bucketed_transition,
+        )
+        bucketed_config = config.bucketed_transition
+        if boundary_mode != bucketed_config.boundary_mode:
+            bucketed_config = replace(bucketed_config, boundary_mode=boundary_mode)
         nonnan_mask = feature_train.notna().to_numpy()
         decoded_aligned = decoded[nonnan_mask]
 
@@ -653,7 +669,7 @@ def _run_side_info_variant(
             n_states=chosen_k,
             baseline_transition_matrix=fitted.transition_matrix,
             bucket_boundaries=boundaries,
-            config=config.bucketed_transition,
+            config=bucketed_config,
         )
 
         posterior_at_train_end = _terminal_training_posterior(train_slice, fitted)
@@ -711,6 +727,7 @@ def _run_side_info_variant(
                 n_train_obs=int(train_slice.shape[0]),
                 n_forecast_obs=int(effective_forecast.shape[0]),
                 bucket_observation_counts=tuple(int(c) for c in bucketed.bucket_observation_counts),
+                boundary_mode=boundary_mode,
                 summary=window_summary,
             )
         )
@@ -735,6 +752,28 @@ def _run_side_info_variant(
         summary=summary,
         cost_bps_per_turnover=float(cost),
     )
+
+
+def _bucket_boundaries_for_mode(
+    *,
+    spline_result: SplinePredictorResult,
+    training_values: np.ndarray,
+    config: BucketedTransitionConfig,
+) -> tuple[np.ndarray, str]:
+    """Resolve bucket boundaries and return the effective boundary mode."""
+    if config.boundary_mode == "grid":
+        return bucket_boundaries_from_spline_grid(spline_result, config=config), "grid"
+    if config.boundary_mode == "quantile":
+        try:
+            return (
+                bucket_boundaries_from_quantiles(
+                    np.asarray(training_values, dtype=float), config=config
+                ),
+                "quantile",
+            )
+        except ValueError:
+            return bucket_boundaries_from_spline_grid(spline_result, config=config), "grid"
+    raise ValueError(f"unsupported boundary_mode {config.boundary_mode!r}.")
 
 
 def _build_feature(
@@ -992,6 +1031,7 @@ def _write_variant_log(path: Path, result: SideInfoVariantResult) -> None:
         }
         if isinstance(w, SideInfoVariantWindow):
             record["bucket_observation_counts"] = list(w.bucket_observation_counts)
+            record["boundary_mode"] = w.boundary_mode
         lines.append(json.dumps(record, sort_keys=True, allow_nan=False))
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 

--- a/src/hft_hmm/models/__init__.py
+++ b/src/hft_hmm/models/__init__.py
@@ -4,6 +4,7 @@ from hft_hmm.models.gaussian_hmm import GaussianHMMResult, GaussianHMMWrapper
 from hft_hmm.models.iohmm_approx import (
     BucketedTransitionConfig,
     BucketedTransitionResult,
+    bucket_boundaries_from_quantiles,
     bucket_boundaries_from_spline_grid,
     fit_bucketed_transition_model,
 )
@@ -24,6 +25,7 @@ __all__ = [
     "PLRBaselineResult",
     "PLRSegment",
     "PLRStateSummary",
+    "bucket_boundaries_from_quantiles",
     "bucket_boundaries_from_spline_grid",
     "fit_bucketed_transition_model",
     "fit_piecewise_linear_regression",

--- a/src/hft_hmm/models/iohmm_approx.py
+++ b/src/hft_hmm/models/iohmm_approx.py
@@ -11,12 +11,23 @@ scheme:
   3. Estimate one K × K row-stochastic transition matrix per bucket using
      additive smoothing toward a pooled baseline matrix.
 
+Boundary placement is configurable in the Gate H experiment. The default
+``grid`` mode keeps the original deterministic behavior: boundaries are spaced
+uniformly over a fitted spline predictor's evaluation support. The opt-in
+``quantile`` mode places boundaries at empirical quantiles of the finite
+training side-information values, which can balance buckets for clustered
+features such as volatility ratios near 1.0.
+
 The result is deterministic, interpretable, and directly usable in Gate H
 experiments where a lookup ``A(x_t)`` replaces the fixed HMM transition matrix.
 
 **This is NOT the exact IOHMM model from the paper.** It is a finite-bucket
-engineering approximation intended for Gate H experiments only.  The paper's
+engineering approximation intended for Gate H experiments only. The paper's
 continuous parametric conditioning is out of scope for the current coursework.
+Both grid and quantile boundary modes remain deviations from the paper's
+continuous-parametric transition conditioning; quantile mode is empirical and
+cannot define strict boundaries for highly discrete features without falling
+back or raising at the caller boundary.
 
 References: §4 side-information / IOHMM approximation
 """
@@ -24,7 +35,7 @@ References: §4 side-information / IOHMM approximation
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Final, cast
+from typing import TYPE_CHECKING, Final, Literal, cast
 
 import numpy as np
 
@@ -37,6 +48,8 @@ __category__: Final[str] = ENGINEERING_APPROXIMATION
 IOHMM_APPROX_REFERENCE: Final[PaperReference] = reference(
     "§4", "side-information / IOHMM approximation"
 )
+BoundaryMode = Literal["grid", "quantile"]
+_VALID_BOUNDARY_MODES: Final[tuple[str, ...]] = ("grid", "quantile")
 
 
 @dataclass(frozen=True)
@@ -49,6 +62,9 @@ class BucketedTransitionConfig:
     ``smoothing > 0``.
     ``grid_size`` is reserved for use by ``bucket_boundaries_from_spline_grid``
     when deriving evaluation-grid boundaries from a spline predictor.
+    ``boundary_mode`` selects the integrated experiment's boundary source:
+    ``"grid"`` preserves the original spline-grid behavior, while
+    ``"quantile"`` opts into empirical quantile boundaries.
 
     References: §4 side-information / IOHMM approximation
     """
@@ -56,6 +72,7 @@ class BucketedTransitionConfig:
     n_buckets: int = 3
     smoothing: float = 1.0
     grid_size: int = 200
+    boundary_mode: BoundaryMode = "grid"
 
     def __post_init__(self) -> None:
         _validate_int(self.n_buckets, "n_buckets")
@@ -66,6 +83,15 @@ class BucketedTransitionConfig:
         _validate_int(self.grid_size, "grid_size")
         if self.grid_size < 2:
             raise ValueError(f"grid_size must be at least 2, got {self.grid_size}.")
+        if not isinstance(self.boundary_mode, str):
+            raise TypeError(
+                f"boundary_mode must be a string, got {type(self.boundary_mode).__name__}."
+            )
+        if self.boundary_mode not in _VALID_BOUNDARY_MODES:
+            raise ValueError(
+                f"boundary_mode must be one of {_VALID_BOUNDARY_MODES}, "
+                f"got {self.boundary_mode!r}."
+            )
 
 
 @dataclass(frozen=True)
@@ -267,6 +293,68 @@ def bucket_boundaries_from_spline_grid(
         np.ndarray,
         np.interp(target_positions, np.arange(config.grid_size, dtype=float), grid),
     )
+
+
+def bucket_boundaries_from_quantiles(
+    values: np.ndarray,
+    *,
+    config: BucketedTransitionConfig | None = None,
+) -> np.ndarray:
+    """Derive bucket boundaries from empirical side-information quantiles.
+
+    ``values`` must be the finite 1-D training side-information values used for
+    transition assignment. The function computes the n_buckets - 1 interior
+    quantiles with ``np.quantile(..., method="linear")`` and returns strictly
+    increasing boundaries suitable for ``fit_bucketed_transition_model``.
+
+    Degenerate empirical distributions are rejected rather than silently
+    reducing the bucket count: if fewer than ``n_buckets`` unique values exist,
+    or duplicate quantile values would violate the strict boundary invariant,
+    the function raises ``ValueError``. The integrated Gate H experiment catches
+    these degeneracies in quantile mode and falls back to the original grid
+    boundary mode for that window.
+
+    References: §4 side-information / IOHMM approximation
+    """
+    if config is None:
+        config = BucketedTransitionConfig()
+    elif not isinstance(config, BucketedTransitionConfig):
+        raise TypeError(f"config must be a BucketedTransitionConfig, got {type(config).__name__}.")
+
+    quantile_values = np.asarray(values, dtype=float)
+    if quantile_values.ndim != 1:
+        raise ValueError(
+            f"values must be one-dimensional for quantile boundaries; "
+            f"got shape {quantile_values.shape}."
+        )
+    if quantile_values.shape[0] < 2:
+        raise ValueError(
+            "values must contain at least 2 observations for quantile boundaries; "
+            f"got {quantile_values.shape[0]}."
+        )
+    if not np.all(np.isfinite(quantile_values)):
+        n_invalid = int(np.sum(~np.isfinite(quantile_values)))
+        raise ValueError(
+            "values must contain only finite entries for quantile boundaries; "
+            f"found {n_invalid} non-finite value(s)."
+        )
+    n_unique = int(np.unique(quantile_values).shape[0])
+    if n_unique < config.n_buckets:
+        raise ValueError(
+            "quantile boundary mode requires at least "
+            f"{config.n_buckets} unique finite value(s); got {n_unique}."
+        )
+
+    levels = np.linspace(0.0, 1.0, config.n_buckets + 1)[1:-1]
+    boundaries = np.asarray(np.quantile(quantile_values, levels, method="linear"), dtype=float)
+    if not np.all(np.isfinite(boundaries)):
+        raise ValueError("quantile boundaries must contain only finite values.")
+    if len(boundaries) > 1 and not np.all(boundaries[:-1] < boundaries[1:]):
+        raise ValueError(
+            "quantile boundary mode produced duplicate boundary values; "
+            "use grid mode or fewer buckets for this empirical distribution."
+        )
+    return cast(np.ndarray, boundaries)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_iohmm_approx.py
+++ b/tests/test_iohmm_approx.py
@@ -11,6 +11,7 @@ from hft_hmm.core.references import ENGINEERING_APPROXIMATION, module_category
 from hft_hmm.models.iohmm_approx import (
     BucketedTransitionConfig,
     BucketedTransitionResult,
+    bucket_boundaries_from_quantiles,
     bucket_boundaries_from_spline_grid,
     fit_bucketed_transition_model,
 )
@@ -64,6 +65,7 @@ def test_config_defaults() -> None:
     assert cfg.n_buckets == 3
     assert cfg.smoothing == 1.0
     assert cfg.grid_size == 200
+    assert cfg.boundary_mode == "grid"
 
 
 def test_config_rejects_n_buckets_below_2() -> None:
@@ -93,6 +95,11 @@ def test_config_rejects_grid_size_below_2() -> None:
 def test_config_rejects_non_integer_grid_size() -> None:
     with pytest.raises(TypeError, match="grid_size must be an integer"):
         BucketedTransitionConfig(grid_size=2.5)  # type: ignore[arg-type]
+
+
+def test_config_rejects_unknown_boundary_mode() -> None:
+    with pytest.raises(ValueError, match="boundary_mode must be one of"):
+        BucketedTransitionConfig(boundary_mode="middle")  # type: ignore[arg-type]
 
 
 # ---------------------------------------------------------------------------
@@ -256,6 +263,22 @@ def test_all_row_sums_are_one(n_buckets: int) -> None:
     result = fit_bucketed_transition_model(
         states, x, config=BucketedTransitionConfig(n_buckets=n_buckets)
     )
+    row_sums = result.transition_matrices.sum(axis=2)
+    np.testing.assert_allclose(row_sums, 1.0, atol=1e-12)
+
+
+def test_all_row_sums_are_one_under_quantile_mode() -> None:
+    states, x = _two_bucket_fixture()
+    cfg = BucketedTransitionConfig(n_buckets=2, boundary_mode="quantile")
+    boundaries = bucket_boundaries_from_quantiles(x[:-1], config=cfg)
+
+    result = fit_bucketed_transition_model(
+        states,
+        x,
+        bucket_boundaries=boundaries,
+        config=cfg,
+    )
+
     row_sums = result.transition_matrices.sum(axis=2)
     np.testing.assert_allclose(row_sums, 1.0, atol=1e-12)
 
@@ -555,6 +578,93 @@ def test_bucket_boundaries_from_spline_grid_rejects_nonmonotone_grid() -> None:
 
 
 # ---------------------------------------------------------------------------
+# bucket_boundaries_from_quantiles helper
+# ---------------------------------------------------------------------------
+
+
+def test_bucket_boundaries_from_quantiles_are_deterministic() -> None:
+    values = np.linspace(-1.0, 1.0, 1001)
+    cfg = BucketedTransitionConfig(n_buckets=4, boundary_mode="quantile")
+
+    boundaries = bucket_boundaries_from_quantiles(values, config=cfg)
+
+    assert boundaries.shape == (3,)
+    np.testing.assert_array_equal(boundaries, np.array([-0.5, 0.0, 0.5]))
+
+
+def test_quantile_boundaries_balance_clustered_bucket_counts_better_than_grid() -> None:
+    class SplineStub:
+        def evaluation_grid(self, n: int) -> tuple[np.ndarray, np.ndarray]:
+            x_grid = np.linspace(0.2, 1.8, n)
+            return x_grid, np.zeros(n)
+
+    transition_values = np.concatenate(
+        [
+            np.full(50, 0.2),
+            np.linspace(0.98, 1.02, 900),
+            np.full(50, 1.8),
+        ]
+    )
+    x = np.concatenate([transition_values, np.array([1.0])])
+    states = np.arange(x.shape[0]) % 2
+    cfg = BucketedTransitionConfig(n_buckets=4, boundary_mode="quantile")
+    grid_boundaries = bucket_boundaries_from_spline_grid(SplineStub(), config=cfg)
+    quantile_boundaries = bucket_boundaries_from_quantiles(transition_values, config=cfg)
+
+    grid_result = fit_bucketed_transition_model(
+        states,
+        x,
+        bucket_boundaries=grid_boundaries,
+        config=cfg,
+    )
+    quantile_result = fit_bucketed_transition_model(
+        states,
+        x,
+        bucket_boundaries=quantile_boundaries,
+        config=cfg,
+    )
+
+    assert (
+        quantile_result.bucket_observation_counts.std()
+        < grid_result.bucket_observation_counts.std()
+    )
+    np.testing.assert_array_equal(
+        quantile_result.bucket_observation_counts,
+        np.array([250, 250, 250, 250]),
+    )
+
+
+def test_bucket_boundaries_from_quantiles_rejects_duplicate_quantiles() -> None:
+    values = np.concatenate(
+        [
+            np.zeros(700),
+            np.ones(100),
+            np.full(100, 2.0),
+            np.full(100, 3.0),
+        ]
+    )
+    cfg = BucketedTransitionConfig(n_buckets=4, boundary_mode="quantile")
+
+    with pytest.raises(ValueError, match="duplicate boundary values"):
+        bucket_boundaries_from_quantiles(values, config=cfg)
+
+
+def test_bucket_boundaries_from_quantiles_rejects_sparse_unique_values() -> None:
+    values = np.array([0.0, 0.0, 1.0, 1.0, 1.0])
+    cfg = BucketedTransitionConfig(n_buckets=4, boundary_mode="quantile")
+
+    with pytest.raises(ValueError, match="requires at least 4 unique"):
+        bucket_boundaries_from_quantiles(values, config=cfg)
+
+
+def test_bucket_boundaries_from_quantiles_rejects_nonfinite_values() -> None:
+    cfg = BucketedTransitionConfig(n_buckets=2, boundary_mode="quantile")
+
+    with pytest.raises(ValueError, match="finite"):
+        bucket_boundaries_from_quantiles(np.array([0.0, np.nan, 1.0]), config=cfg)
+
+
+# ---------------------------------------------------------------------------
 # __init__.py re-exports
 # ---------------------------------------------------------------------------
 
@@ -564,5 +674,6 @@ def test_exports_available_from_models_package() -> None:
 
     assert hasattr(models, "BucketedTransitionConfig")
     assert hasattr(models, "BucketedTransitionResult")
+    assert hasattr(models, "bucket_boundaries_from_quantiles")
     assert hasattr(models, "fit_bucketed_transition_model")
     assert hasattr(models, "iohmm_approx")

--- a/tests/test_side_info_comparison.py
+++ b/tests/test_side_info_comparison.py
@@ -7,6 +7,7 @@ import json
 import subprocess
 import sys
 from copy import deepcopy
+from dataclasses import replace
 from pathlib import Path
 
 import numpy as np
@@ -85,6 +86,7 @@ def test_config_yaml_round_trip_and_deterministic_id(tmp_path: Path) -> None:
     assert loaded.frequency == cfg.frequency
     assert loaded.walk_forward.h_days == cfg.walk_forward.h_days
     assert loaded.bucketed_transition.n_buckets == cfg.bucketed_transition.n_buckets
+    assert loaded.bucketed_transition.boundary_mode == cfg.bucketed_transition.boundary_mode
     assert loaded.vol_ratio.fast_window == cfg.vol_ratio.fast_window
     assert loaded.seasonality.bucket_minutes == cfg.seasonality.bucket_minutes
     assert loaded.spline.n_knots == cfg.spline.n_knots
@@ -180,7 +182,66 @@ def test_artifact_layout_is_written(comparison_artifacts) -> None:
     assert (directory / "summary.json").is_file()
     assert (directory / "figures").is_dir()
     for variant in EXPECTED_VARIANTS:
-        assert (directory / f"{variant}.log.jsonl").is_file()
+        log_path = directory / f"{variant}.log.jsonl"
+        assert log_path.is_file()
+        first_record = json.loads(log_path.read_text().splitlines()[0])
+        if variant != BASELINE_VARIANT:
+            assert first_record["boundary_mode"] == "grid"
+
+
+@pytest.mark.parametrize(
+    ("feature_shape", "expected_mode"),
+    [
+        ("unique", "quantile"),
+        ("duplicate_quantiles", "grid"),
+    ],
+)
+def test_quantile_boundary_mode_logs_effective_mode(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    feature_shape: str,
+    expected_mode: str,
+) -> None:
+    def fake_feature(
+        variant: str,
+        series: pd.Series,
+        config: SideInfoComparisonConfig,
+    ) -> pd.Series:
+        del variant, config
+        n_obs = len(series)
+        if feature_shape == "unique":
+            values = np.linspace(0.0, 1.0, n_obs)
+        else:
+            split = int(0.70 * n_obs)
+            values = np.concatenate(
+                [
+                    np.zeros(split),
+                    np.linspace(1.0, 2.0, n_obs - split),
+                ]
+            )
+        return pd.Series(values, index=series.index)
+
+    monkeypatch.setattr(side_info_module, "_build_feature", fake_feature)
+    cfg = replace(
+        _make_config(),
+        bucketed_transition=BucketedTransitionConfig(
+            n_buckets=4,
+            smoothing=1.0,
+            boundary_mode="quantile",
+        ),
+    )
+
+    artifacts = run_side_info_comparison(cfg, runs_root=tmp_path)
+
+    for variant in EXPECTED_VARIANTS:
+        records = [
+            json.loads(line)
+            for line in (artifacts.directory / f"{variant}.log.jsonl").read_text().splitlines()
+        ]
+        if variant == BASELINE_VARIANT:
+            assert all("boundary_mode" not in record for record in records)
+        else:
+            assert {record["boundary_mode"] for record in records} == {expected_mode}
 
 
 def test_force_overwrites_existing_directory(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Adds opt-in `quantile` boundary mode to `BucketedTransitionConfig`; default `grid` mode is preserved bit-for-bit.
- New `bucket_boundaries_from_quantiles` helper places boundaries at empirical quantiles of finite training values and rejects degenerate distributions (duplicate quantiles, sparse unique values, non-finite input) with `ValueError`.
- The integrated side-info experiment catches degeneracies per-window and falls back to grid mode, recording the effective `boundary_mode` in each per-window log entry.

This is also the fair-baseline prerequisite for the planned HMC IOHMM extension: without quantile boundaries any HMC win would be confounded with bucket imbalance rather than continuous-parametric conditioning.

Closes #42.

## Test plan
- [x] `pytest tests/test_iohmm_approx.py` — quantile helper: determinism, balance vs grid on clustered data, duplicate-quantile rejection, sparse-unique-values rejection, non-finite rejection, row-normalization invariant under quantile mode.
- [x] `pytest tests/test_side_info_comparison.py` — integration: quantile mode logs `boundary_mode == "quantile"` on a unique feature; fallback logs `boundary_mode == "grid"` on a duplicate-quantile feature; YAML round-trip preserves `boundary_mode`.
- [x] `pytest` — full suite, 488 passed.
- [x] `ruff check .`, `black --check src/ tests/` — clean.
- [x] No `runs/` artifacts touched; existing Gate H run hashes unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional quantile-based boundary mode for bucketed IOHMM transitions, with deterministic quantile computation and graceful fallback to grid when needed.
  * Comparison runs now record the effective boundary mode used for each variant.

* **Tests**
  * Expanded test coverage for quantile boundary behavior, validation, row-normalization invariants, and edge cases.

* **Documentation**
  * Added acceptance gate and detailed issue specification describing the quantile boundary mode and required deliverables.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SantiBarrios2002/hmm-trading/pull/46)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->