### PR TITLE
Gate L P2: causal DMM forecast surface + predictive gating realignment

### DIFF
--- a/src/hft_hmm/models/dmm.py
+++ b/src/hft_hmm/models/dmm.py
@@ -5,16 +5,21 @@ described by Krishnan, Shalit, and Sontag (2017, §3-4), adapted for return
 sequences with optional exogenous side information. The latent process is a
 nonlinear Gaussian state-space model:
 
-``z_t | z_{t-1}, x_t ~ Normal(mu_trans(z_{t-1}, x_t), sigma_trans(z_{t-1}, x_t))``
+``z_t | z_{t-1}, x_{t-1} ~ Normal(mu_trans(z_{t-1}, x_{t-1}), sigma_trans(z_{t-1}, x_{t-1}))``
 
 ``y_t | z_t ~ Normal(mu_emit(z_t), sigma_emit(z_t))``
 
 ``q(z_t | z_{t-1}, y_{t:T}) = Normal(mu_q(z_{t-1}, h_t), sigma_q(z_{t-1}, h_t))``
 
 where ``h_t`` is produced by a reverse-time recurrent network over the observed
-return sequence. The transition network accepts optional side information
-``x_t``; when no side information is provided, the model falls back to a zero
-vector so the same module can be used in ablations without exogenous features.
+return sequence. Side information gates the transition **predictively**, IOHMM-style:
+the exogenous row ``x_{t-1}`` governs the ``(t-1) -> t`` transition (the first
+latent has no incoming row and is left ungated). This matches the bucketed/continuous
+IOHMM convention where ``A(x_t)`` parameterizes the ``t -> t+1`` step, so the causal
+one-step-ahead forecast in :func:`expected_next_returns_from_dmm` (which uses
+``x_t`` for the ``t -> t+1`` transition) is consistent with training. When no side
+information is provided the model falls back to a zero vector, so the same module can
+be used in ablations without exogenous features.
 
 Variable-length mini-batches are represented as padded tensors plus
 ``seq_lengths``. The model and guide preserve the P0 spike's masking strategy so
@@ -458,7 +463,15 @@ class DMM(nn.Module):
 
         with pyro.plate("z_minibatch", observations_prepared.size(0)):
             for t in pyro.markov(range(time_steps)):
-                side_info_step = side_info_prepared[:, t, :] if self.side_info_dim > 0 else None
+                # Predictive (IOHMM-style) gating: the exogenous row x[t-1]
+                # governs the (t-1)->t transition, so the causal one-step-ahead
+                # forecast (which uses x[t] for the t->t+1 transition) is
+                # consistent with training. The first latent has no incoming
+                # exogenous row (initial transition) and is left ungated.
+                if self.side_info_dim > 0 and t > 0:
+                    side_info_step = side_info_prepared[:, t - 1, :]
+                else:
+                    side_info_step = None
                 z_loc, z_scale = self.trans(z_prev, side_info_step)
                 with poutine.scale(scale=float(annealing_factor)):
                     z_t = pyro.sample(
@@ -803,11 +816,11 @@ def expected_next_returns_from_dmm(
     running the guide on each expanding prefix ``Δy_{1:t}`` separately,
     propagating the deterministic guide mean at ``z_t`` one step ahead through
     the transition network, and mapping that next-latent mean through the
-    emission network. The one-step-ahead transition uses ``side_info[t]``,
-    matching the existing side-information forecast convention in the IOHMM
-    path: the exogenous row observed at bar ``t`` parameterizes the forecast
-    for bar ``t + 1``. At the horizon edge, the final forecast therefore uses
-    the last available side-information row rather than reading a future row.
+    emission network. The one-step-ahead transition uses ``side_info[t]``: under
+    the model's predictive (IOHMM-style) gating, ``x_t`` is exactly the exogenous
+    row that governs the ``t -> t+1`` transition, so this forecast is consistent
+    with how the DMM was trained (no one-step input lag). Only causally available
+    rows are read; the forecast for bar ``t + 1`` uses ``x_t``, never a future row.
 
     Returns a finite ``pd.Series`` aligned to the input return index (or a
     positional ``RangeIndex`` when ``returns`` is a raw numpy array).

--- a/src/hft_hmm/models/dmm.py
+++ b/src/hft_hmm/models/dmm.py
@@ -35,6 +35,7 @@ from dataclasses import dataclass
 from typing import Final, cast
 
 import numpy as np
+import pandas as pd
 import pyro
 import pyro.distributions as dist
 import pyro.poutine as poutine
@@ -791,6 +792,87 @@ def fit_dmm(
     return DMMFitResult(config=config, model=dmm, loss_history=tuple(loss_history))
 
 
+def expected_next_returns_from_dmm(
+    fitted: DMM | DMMFitResult,
+    returns: pd.Series | np.ndarray,
+    side_info: pd.Series | pd.DataFrame | np.ndarray | None = None,
+) -> pd.Series:
+    """Return the causal DMM forecast surface ``E[Δy_{t+1} | Δy_{1:t}]``.
+
+    The guide is a reverse-time smoother, so this helper avoids look-ahead by
+    running the guide on each expanding prefix ``Δy_{1:t}`` separately,
+    propagating the deterministic guide mean at ``z_t`` one step ahead through
+    the transition network, and mapping that next-latent mean through the
+    emission network. The one-step-ahead transition uses ``side_info[t]``,
+    matching the existing side-information forecast convention in the IOHMM
+    path: the exogenous row observed at bar ``t`` parameterizes the forecast
+    for bar ``t + 1``. At the horizon edge, the final forecast therefore uses
+    the last available side-information row rather than reading a future row.
+
+    Returns a finite ``pd.Series`` aligned to the input return index (or a
+    positional ``RangeIndex`` when ``returns`` is a raw numpy array).
+
+    References: Krishnan et al. (2017) §3-4
+    """
+
+    dmm = _coerce_dmm_forecast_model(fitted)
+    if dmm.obs_dim != 1:
+        raise ValueError(
+            "expected_next_returns_from_dmm currently supports only obs_dim=1 "
+            f"models, got obs_dim={dmm.obs_dim}."
+        )
+
+    return_values, return_index = _coerce_return_forecast_series(returns)
+    n_obs = return_values.shape[0]
+    parameter = next(dmm.parameters())
+    device = parameter.device
+    dtype = parameter.dtype
+
+    observations = torch.as_tensor(
+        return_values.reshape(1, n_obs, dmm.obs_dim),
+        device=device,
+        dtype=dtype,
+    )
+    side_info_tensor = _coerce_forecast_side_info(
+        side_info,
+        return_index=return_index,
+        n_obs=n_obs,
+        side_info_dim=dmm.side_info_dim,
+        device=device,
+        dtype=dtype,
+    )
+
+    was_training = dmm.training
+    dmm.eval()
+    expected = np.empty(n_obs, dtype=float)
+
+    try:
+        with torch.no_grad():
+            for t in range(n_obs):
+                prefix_length = t + 1
+                prefix_observations = observations[:, :prefix_length, :]
+                prefix_side_info = (
+                    side_info_tensor[:, :prefix_length, :] if side_info_tensor is not None else None
+                )
+                filtered_latent_mean = _filtered_latent_mean_for_prefix(
+                    dmm,
+                    prefix_observations=prefix_observations,
+                    prefix_side_info=prefix_side_info,
+                )
+                transition_side_info = (
+                    side_info_tensor[:, t, :] if side_info_tensor is not None else None
+                )
+                next_latent_loc, _ = dmm.trans(filtered_latent_mean, transition_side_info)
+                emission_loc, _ = dmm.emitter(next_latent_loc)
+                expected[t] = float(emission_loc.squeeze().item())
+    finally:
+        dmm.train(was_training)
+
+    if not np.all(np.isfinite(expected)):
+        raise ValueError("DMM expected_next_returns must contain only finite values.")
+    return pd.Series(expected, index=return_index, name="expected_next_returns")
+
+
 def _coerce_observations(observations: torch.Tensor, *, obs_dim: int) -> torch.Tensor:
     if observations.ndim != 3:
         raise ValueError(
@@ -915,6 +997,114 @@ def _pad_and_reverse(
 ) -> torch.Tensor:
     unpacked, _ = pad_packed_sequence(rnn_output, batch_first=True, total_length=total_length)
     return _reverse_sequences(unpacked, seq_lengths)
+
+
+def _coerce_dmm_forecast_model(fitted: DMM | DMMFitResult) -> DMM:
+    if isinstance(fitted, DMMFitResult):
+        return fitted.model
+    if isinstance(fitted, DMM):
+        return fitted
+    raise TypeError(f"fitted must be a DMM or DMMFitResult, got {type(fitted).__name__}.")
+
+
+def _coerce_return_forecast_series(
+    returns: pd.Series | np.ndarray,
+) -> tuple[np.ndarray, pd.Index]:
+    if isinstance(returns, pd.Series):
+        values = np.asarray(returns, dtype=float)
+        index = returns.index
+    else:
+        values = np.asarray(returns, dtype=float)
+        index = pd.RangeIndex(start=0, stop=values.shape[0])
+    if values.ndim != 1:
+        raise ValueError(f"returns must be one-dimensional, got shape {values.shape}.")
+    if values.size < 1:
+        raise ValueError("returns must contain at least one observation.")
+    if not np.all(np.isfinite(values)):
+        raise ValueError("returns must contain only finite values; drop NaN/inf first.")
+    return values.copy(), index
+
+
+def _coerce_forecast_side_info(
+    side_info: pd.Series | pd.DataFrame | np.ndarray | None,
+    *,
+    return_index: pd.Index,
+    n_obs: int,
+    side_info_dim: int,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> torch.Tensor | None:
+    if side_info_dim == 0:
+        if side_info is not None:
+            raise ValueError("side_info was provided but side_info_dim=0 for this DMM.")
+        return None
+    if side_info is None:
+        raise ValueError(
+            "side_info must be provided when forecasting with a DMM that expects exogenous inputs."
+        )
+
+    if isinstance(side_info, pd.DataFrame):
+        side_values = side_info.to_numpy(dtype=float, copy=True)
+        _validate_forecast_side_info_index(side_info.index, return_index)
+    elif isinstance(side_info, pd.Series):
+        side_values = side_info.to_numpy(dtype=float, copy=True).reshape(-1, 1)
+        _validate_forecast_side_info_index(side_info.index, return_index)
+    else:
+        side_values = np.asarray(side_info, dtype=float)
+        if side_values.ndim == 1:
+            side_values = side_values.reshape(-1, 1)
+
+    if side_values.ndim != 2:
+        raise ValueError(
+            "side_info must be one-dimensional or two-dimensional, "
+            f"got shape {side_values.shape}."
+        )
+    expected_shape = (n_obs, side_info_dim)
+    if side_values.shape != expected_shape:
+        raise ValueError(f"side_info must have shape {expected_shape}, got {side_values.shape}.")
+    if not np.all(np.isfinite(side_values)):
+        raise ValueError("side_info must contain only finite values; drop NaN/inf first.")
+    return torch.as_tensor(side_values.reshape(1, n_obs, side_info_dim), device=device, dtype=dtype)
+
+
+def _validate_forecast_side_info_index(side_info_index: pd.Index, return_index: pd.Index) -> None:
+    if not side_info_index.equals(return_index):
+        raise ValueError("side_info index must exactly match the return-series index.")
+
+
+def _filtered_latent_mean_for_prefix(
+    dmm: DMM,
+    *,
+    prefix_observations: torch.Tensor,
+    prefix_side_info: torch.Tensor | None,
+) -> torch.Tensor:
+    batch_size, time_steps, _ = prefix_observations.shape
+    seq_lengths = torch.full(
+        (batch_size,),
+        time_steps,
+        dtype=torch.long,
+        device=prefix_observations.device,
+    )
+    observations_prepared, _, _, seq_lengths_prepared = dmm._prepare_inputs(
+        observations=prefix_observations,
+        side_info=prefix_side_info,
+        seq_lengths=seq_lengths,
+    )
+    h_0_contiguous = dmm.h_0.expand(dmm.num_layers, batch_size, dmm.rnn_dim).contiguous()
+    rnn_output, _ = dmm.rnn(
+        _pack_reversed_sequences(observations_prepared, seq_lengths_prepared),
+        h_0_contiguous,
+    )
+    rnn_output_padded = _pad_and_reverse(
+        rnn_output,
+        seq_lengths_prepared,
+        total_length=time_steps,
+    )
+    z_prev = dmm.z_q_0.expand(batch_size, dmm.z_dim)
+    for step in range(time_steps):
+        z_loc, _ = dmm.combiner(z_prev, rnn_output_padded[:, step, :])
+        z_prev = z_loc
+    return z_prev
 
 
 def _validate_positive_int(value: int, name: str) -> None:

--- a/tests/test_dmm.py
+++ b/tests/test_dmm.py
@@ -303,6 +303,52 @@ def test_guide_handles_padding_wider_than_longest_sequence() -> None:
     assert torch.isfinite(torch.as_tensor(guide_trace.log_prob_sum()))
 
 
+def test_model_transition_gating_is_predictive() -> None:
+    # Predictive (IOHMM-style) gating: x[k] governs the k -> k+1 transition, so it
+    # parameterizes the latent that emits y[k+1] (site "z_{k+2}"), not the
+    # contemporaneous latent for y[k] (site "z_{k+1}"). Conditioning all latents
+    # isolates the transition-site log-probs.
+    pyro.clear_param_store()
+    torch.manual_seed(0)
+    batch_size = 1
+    time_steps = 5
+    obs_dim = 1
+    side_info_dim = 2
+    z_dim = 3
+    changed_index = 2  # interior bar k
+
+    observations = torch.randn(batch_size, time_steps, obs_dim)
+    side_info = torch.randn(batch_size, time_steps, side_info_dim)
+    side_info_alt = side_info.clone()
+    side_info_alt[:, changed_index, :] += torch.tensor([3.0, -3.0])
+
+    dmm = DMM(obs_dim=obs_dim, z_dim=z_dim, side_info_dim=side_info_dim, rnn_dim=6)
+    latent_values = {f"z_{step + 1}": torch.randn(batch_size, z_dim) for step in range(time_steps)}
+    conditioned = poutine.condition(dmm.model, data=latent_values)
+
+    def latent_site_log_probs(side: torch.Tensor) -> dict[str, float]:
+        trace = poutine.trace(conditioned).get_trace(observations, side, None, 1.0)
+        trace.compute_log_prob()
+        return {
+            name: float(node["log_prob"].sum().item())
+            for name, node in trace.nodes.items()
+            if name.startswith("z_")
+        }
+
+    base = latent_site_log_probs(side_info)
+    alt = latent_site_log_probs(side_info_alt)
+
+    predictive_site = f"z_{changed_index + 2}"  # latent emitting y[k+1]
+    contemporaneous_site = f"z_{changed_index + 1}"  # latent emitting y[k]
+    for name in base:
+        if name == predictive_site:
+            assert not np.isclose(base[name], alt[name]), f"{name} should change with x[k]."
+        else:
+            assert np.isclose(base[name], alt[name]), f"{name} should be unchanged by x[k]."
+    # The contemporaneous latent in particular must not move (rules out the old lag).
+    assert np.isclose(base[contemporaneous_site], alt[contemporaneous_site])
+
+
 def test_kl_annealing_factor_matches_expected_schedule() -> None:
     kwargs = {
         "num_minibatches": 5,

--- a/tests/test_dmm.py
+++ b/tests/test_dmm.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib
 
 import numpy as np
+import pandas as pd
 import pytest
 
 pytest.importorskip("torch")
@@ -19,11 +20,14 @@ from hft_hmm.models.dmm import (  # noqa: E402
     DMM,
     Combiner,
     DMMConfig,
+    DMMFitResult,
     Emitter,
     GatedTransition,
+    expected_next_returns_from_dmm,
     fit_dmm,
     kl_annealing_factor,
 )
+from hft_hmm.strategy.signals import build_signal  # noqa: E402
 
 
 def _synthetic_training_batch() -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
@@ -44,6 +48,70 @@ def _synthetic_training_batch() -> tuple[torch.Tensor, torch.Tensor, torch.Tenso
     observations = slope + curvature + offsets
     seq_lengths = torch.full((batch_size,), time_steps, dtype=torch.long)
     return observations, side_info, seq_lengths
+
+
+@pytest.fixture(scope="module")
+def fitted_dmm_for_forecast() -> DMMFitResult:
+    observations, side_info, seq_lengths = _synthetic_training_batch()
+    config = DMMConfig(
+        obs_dim=1,
+        z_dim=3,
+        emission_dim=6,
+        transition_dim=6,
+        rnn_dim=7,
+        side_info_dim=2,
+        num_epochs=4,
+        mini_batch_size=4,
+        learning_rate=1e-2,
+        beta1=0.9,
+        beta2=0.999,
+        clip_norm=5.0,
+        lr_decay=1.0,
+        weight_decay=0.0,
+        rnn_dropout_rate=0.0,
+        min_annealing_factor=0.2,
+        annealing_epochs=2,
+        seed=31,
+    )
+    previous_threads = torch.get_num_threads()
+    try:
+        torch.set_num_threads(1)
+        return fit_dmm(config, observations, side_info, seq_lengths)
+    finally:
+        torch.set_num_threads(previous_threads)
+
+
+def _forecast_window_inputs(
+    length: int = 6,
+) -> tuple[pd.Series, pd.DataFrame]:
+    index = pd.date_range("2024-01-02 09:30:00", periods=length, freq="min")
+    returns = pd.Series(np.linspace(-0.015, 0.018, num=length), index=index, name="returns")
+    side_info = pd.DataFrame(
+        {
+            "level": np.linspace(-1.0, 1.0, num=length),
+            "curvature": np.linspace(0.25, 1.25, num=length),
+        },
+        index=index,
+    )
+    return returns, side_info
+
+
+def _constant_forecast_dmm(*, constant: float, side_info_dim: int) -> DMM:
+    dmm = DMM(
+        obs_dim=1,
+        z_dim=2,
+        emission_dim=4,
+        transition_dim=4,
+        rnn_dim=4,
+        side_info_dim=side_info_dim,
+        rnn_dropout_rate=0.0,
+    )
+    with torch.no_grad():
+        for parameter in dmm.parameters():
+            parameter.zero_()
+        dmm.emitter.lin_hidden_to_loc.bias.fill_(constant)
+    dmm.eval()
+    return dmm
 
 
 def test_module_declares_engineering_approximation() -> None:
@@ -318,3 +386,77 @@ def test_fit_dmm_is_reproducible_within_tolerance_at_one_thread() -> None:
         torch.set_num_threads(previous_threads)
 
     np.testing.assert_allclose(first.loss_history, second.loss_history, atol=atol, rtol=0.0)
+
+
+def test_expected_next_returns_from_dmm_returns_index_aligned_series(
+    fitted_dmm_for_forecast: DMMFitResult,
+) -> None:
+    forecast_returns, forecast_side_info = _forecast_window_inputs()
+
+    expected = expected_next_returns_from_dmm(
+        fitted_dmm_for_forecast,
+        forecast_returns,
+        forecast_side_info,
+    )
+
+    assert isinstance(expected, pd.Series)
+    assert len(expected) == len(forecast_returns)
+    pd.testing.assert_index_equal(expected.index, forecast_returns.index)
+    assert np.all(np.isfinite(expected.to_numpy()))
+
+
+def test_expected_next_returns_from_dmm_is_causal_on_prefixes(
+    fitted_dmm_for_forecast: DMMFitResult,
+) -> None:
+    forecast_returns, forecast_side_info = _forecast_window_inputs(length=7)
+    prefix_length = 4
+
+    full_expected = expected_next_returns_from_dmm(
+        fitted_dmm_for_forecast,
+        forecast_returns,
+        forecast_side_info,
+    )
+    prefix_expected = expected_next_returns_from_dmm(
+        fitted_dmm_for_forecast,
+        forecast_returns.iloc[:prefix_length],
+        forecast_side_info.iloc[:prefix_length],
+    )
+
+    pd.testing.assert_series_equal(full_expected.iloc[:prefix_length], prefix_expected)
+
+
+def test_expected_next_returns_from_dmm_collapses_on_near_constant_series() -> None:
+    constant_level = 0.0125
+    forecast_model = _constant_forecast_dmm(constant=constant_level, side_info_dim=1)
+    index = pd.date_range("2024-01-03 09:30:00", periods=5, freq="min")
+    returns = pd.Series(
+        constant_level + np.array([0.0, 1e-4, -1e-4, 5e-5, -5e-5]),
+        index=index,
+    )
+    side_info = pd.Series(np.linspace(-0.5, 0.5, num=len(index)), index=index, name="feature")
+
+    expected = expected_next_returns_from_dmm(forecast_model, returns, side_info)
+
+    assert np.all(np.isfinite(expected.to_numpy()))
+    np.testing.assert_allclose(
+        expected.to_numpy(),
+        np.full(len(expected), constant_level),
+        atol=1e-6,
+        rtol=0.0,
+    )
+
+
+def test_expected_next_returns_from_dmm_feeds_build_signal(
+    fitted_dmm_for_forecast: DMMFitResult,
+) -> None:
+    forecast_returns, forecast_side_info = _forecast_window_inputs()
+    expected = expected_next_returns_from_dmm(
+        fitted_dmm_for_forecast,
+        forecast_returns,
+        forecast_side_info,
+    )
+
+    signal = build_signal(expected, policy="sign")
+
+    assert isinstance(signal, pd.Series)
+    pd.testing.assert_index_equal(signal.index, forecast_returns.index)


### PR DESCRIPTION
**Update (review):** also realigns the DMM transition gating to **predictive (IOHMM-style)** — `x[t-1]` governs the `(t-1)→t` transition — so the causal forecast's use of `x[t]` for the `t→t+1` step is now consistent with training (removes the one-step input lag). Guide and forecast code unchanged; only the model's side-info index shifts. New test `test_model_transition_gating_is_predictive` locks the convention.

---

## Summary
- add a causal expected_next_returns_from_dmm helper that produces an index-aligned pandas Series forecast surface from a fitted DMM
- implement deterministic expanding-prefix mean propagation so the DMM smoother cannot leak future observations into earlier forecasts
- add DMM forecast tests for shape/index alignment, causality, near-constant stability, and build_signal compatibility

## Validation
- .venv/bin/black --check src/hft_hmm/models/dmm.py tests/test_dmm.py
- .venv/bin/ruff check src/hft_hmm/models/dmm.py tests/test_dmm.py
- .venv/bin/mypy src
- .venv/bin/pytest tests/test_dmm.py --no-cov

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced one-step-ahead forecasting for Dynamic Mixture Models. Users can now generate next-period return predictions from fitted models with automatic input validation and chronological index preservation.

* **Tests**
  * Added comprehensive test coverage validating forecasting accuracy, causal properties, consistency across different input windows, and integration with standard data workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
