### PR TITLE
Wire DMM variant into side-info comparison

### DIFF
--- a/configs/example_es_side_info_comparison.yaml
+++ b/configs/example_es_side_info_comparison.yaml
@@ -19,6 +19,27 @@ data:
   path: tests/fixtures/es_1min_month.csv
   start: null
   symbol: null
+dmm:
+  annealing_epochs: 1
+  beta1: 0.96
+  beta2: 0.999
+  clip_norm: 10.0
+  emission_dim: 8
+  learning_rate: 0.0003
+  lr_decay: 0.99996
+  min_annealing_factor: 0.2
+  min_scale: 0.0001
+  mini_batch_size: 20
+  num_epochs: 2
+  num_layers: 1
+  obs_dim: 1
+  rnn_dim: 8
+  rnn_dropout_rate: 0.1
+  seed: 54
+  side_info_dim: 0
+  transition_dim: 8
+  weight_decay: 2.0
+  z_dim: 4
 frequency: 1min
 notes: Gate H/K side-information comparison on January 2024 ES CSV fixture; baseline
   vs bucketed and HMC continuous volatility-ratio and intraday-seasonality

--- a/src/hft_hmm/__init__.py
+++ b/src/hft_hmm/__init__.py
@@ -52,6 +52,7 @@ from hft_hmm.experiments import (
 from hft_hmm.experiments.runner import NON_REPRODUCIBLE_WARNING, RunArtifacts, run_experiment
 from hft_hmm.experiments.side_info_comparison import (
     BASELINE_VARIANT,
+    DMM_VARIANT,
     EXPECTED_VARIANTS,
     SEASONALITY_HMC_CONTINUOUS_VARIANT,
     SEASONALITY_VARIANT,
@@ -60,6 +61,7 @@ from hft_hmm.experiments.side_info_comparison import (
     VOLATILITY_RATIO_HMC_CONTINUOUS_VARIANT,
     VOLATILITY_RATIO_VARIANT,
     ContinuousSideInfoVariantWindow,
+    DmmVariantWindow,
     SideInfoComparisonArtifacts,
     SideInfoComparisonConfig,
     SideInfoComparisonResult,
@@ -134,6 +136,7 @@ __all__ = [
     "EXPERIMENT_CONFIG_REFERENCE",
     "INTRADAY_SEASONALITY_REFERENCE",
     "BASELINE_VARIANT",
+    "DMM_VARIANT",
     "EXPECTED_VARIANTS",
     "NON_REPRODUCIBLE_WARNING",
     "SEASONALITY_HMC_CONTINUOUS_VARIANT",
@@ -198,6 +201,7 @@ __all__ = [
     "cumulative_return",
     "daily_annualized_sharpe_ratio",
     "default_labels",
+    "DmmVariantWindow",
     "ewma_volatility",
     "fit_continuous_iohmm",
     "fit_piecewise_linear_regression",

--- a/src/hft_hmm/experiments/side_info_comparison.py
+++ b/src/hft_hmm/experiments/side_info_comparison.py
@@ -53,6 +53,7 @@ from typing import Any, Final, TypeVar
 
 import numpy as np
 import pandas as pd
+import torch
 import yaml
 from scipy.special import logsumexp
 
@@ -92,6 +93,7 @@ from hft_hmm.features.volatility_ratio import VolatilityRatioConfig, volatility_
 from hft_hmm.inference import filter_from_result
 from hft_hmm.inference.forward_filter import forward_filter
 from hft_hmm.models.default_hmm import fit_default_hmm
+from hft_hmm.models.dmm import DMMConfig, expected_next_returns_from_dmm, fit_dmm
 from hft_hmm.models.gaussian_hmm import GaussianHMMResult, GaussianHMMWrapper
 from hft_hmm.models.iohmm_approx import (
     BoundaryMode,
@@ -132,6 +134,7 @@ VOLATILITY_RATIO_HMC_CONTINUOUS_VARIANT: Final[str] = "volatility_ratio_hmc_cont
 SEASONALITY_HMC_CONTINUOUS_VARIANT: Final[str] = "seasonality_hmc_continuous"
 VOL_RATIO_SEASONALITY_HMC_CONTINUOUS_VARIANT: Final[str] = "vol_ratio_seasonality_hmc_continuous"
 DEFAULT_HMM_VARIANT: Final[str] = "default_hmm"
+DMM_VARIANT: Final[str] = "dmm"
 EXPECTED_VARIANTS: Final[tuple[str, ...]] = (
     BASELINE_VARIANT,
     VOLATILITY_RATIO_VARIANT,
@@ -139,6 +142,7 @@ EXPECTED_VARIANTS: Final[tuple[str, ...]] = (
     VOLATILITY_RATIO_HMC_CONTINUOUS_VARIANT,
     SEASONALITY_HMC_CONTINUOUS_VARIANT,
     VOL_RATIO_SEASONALITY_HMC_CONTINUOUS_VARIANT,
+    DMM_VARIANT,
     DEFAULT_HMM_VARIANT,
 )
 _SIDE_INFO_VARIANTS: Final[tuple[str, ...]] = (
@@ -148,6 +152,8 @@ _SIDE_INFO_VARIANTS: Final[tuple[str, ...]] = (
     SEASONALITY_HMC_CONTINUOUS_VARIANT,
     VOL_RATIO_SEASONALITY_HMC_CONTINUOUS_VARIANT,
 )
+_DMM_FEATURE_IDENTITY: Final[str] = "volatility_ratio"
+_MIN_STANDARDIZATION_STD: Final[float] = 1e-12
 _HMC_CONTINUOUS_VARIANTS: Final[tuple[str, ...]] = (
     VOLATILITY_RATIO_HMC_CONTINUOUS_VARIANT,
     SEASONALITY_HMC_CONTINUOUS_VARIANT,
@@ -179,6 +185,7 @@ class SideInfoComparisonConfig:
     spline: SplinePredictorConfig = field(default_factory=SplinePredictorConfig)
     bucketed_transition: BucketedTransitionConfig = field(default_factory=BucketedTransitionConfig)
     continuous_iohmm: ContinuousIOHMMConfig = field(default_factory=ContinuousIOHMMConfig)
+    dmm: DMMConfig = field(default_factory=DMMConfig)
     vol_ratio: VolatilityRatioConfig = field(default_factory=VolatilityRatioConfig)
     seasonality: SeasonalityConfig = field(default_factory=SeasonalityConfig)
     cost_bps_per_turnover: float = 0.0
@@ -213,6 +220,8 @@ class SideInfoComparisonConfig:
                 "continuous_iohmm must be a ContinuousIOHMMConfig, "
                 f"got {type(self.continuous_iohmm).__name__}."
             )
+        if not isinstance(self.dmm, DMMConfig):
+            raise TypeError(f"dmm must be a DMMConfig, got {type(self.dmm).__name__}.")
         if not isinstance(self.vol_ratio, VolatilityRatioConfig):
             raise TypeError(
                 "vol_ratio must be a VolatilityRatioConfig, "
@@ -288,6 +297,28 @@ class SideInfoComparisonConfig:
             },
             "cost_bps_per_turnover": float(self.cost_bps_per_turnover),
             "data": self.data.to_dict(),
+            "dmm": {
+                "annealing_epochs": int(self.dmm.annealing_epochs),
+                "beta1": float(self.dmm.beta1),
+                "beta2": float(self.dmm.beta2),
+                "clip_norm": float(self.dmm.clip_norm),
+                "emission_dim": int(self.dmm.emission_dim),
+                "learning_rate": float(self.dmm.learning_rate),
+                "lr_decay": float(self.dmm.lr_decay),
+                "min_annealing_factor": float(self.dmm.min_annealing_factor),
+                "min_scale": float(self.dmm.min_scale),
+                "mini_batch_size": int(self.dmm.mini_batch_size),
+                "num_epochs": int(self.dmm.num_epochs),
+                "num_layers": int(self.dmm.num_layers),
+                "obs_dim": int(self.dmm.obs_dim),
+                "rnn_dim": int(self.dmm.rnn_dim),
+                "rnn_dropout_rate": float(self.dmm.rnn_dropout_rate),
+                "seed": int(self.dmm.seed),
+                "side_info_dim": int(self.dmm.side_info_dim),
+                "transition_dim": int(self.dmm.transition_dim),
+                "weight_decay": float(self.dmm.weight_decay),
+                "z_dim": int(self.dmm.z_dim),
+            },
             "frequency": self.frequency,
             "notes": self.notes,
             "seasonality": {
@@ -374,6 +405,31 @@ class SideInfoComparisonConfig:
             rhat_threshold=float(ci_raw.get("rhat_threshold", 1.05)),
             ess_bulk_threshold=int(ci_raw.get("ess_bulk_threshold", 200)),
         )
+        dmm_raw = raw.get("dmm", {})
+        if not isinstance(dmm_raw, Mapping):
+            raise ValueError(f"dmm must be a mapping; got {type(dmm_raw).__name__}.")
+        dmm = DMMConfig(
+            obs_dim=int(dmm_raw.get("obs_dim", 1)),
+            z_dim=int(dmm_raw.get("z_dim", 16)),
+            emission_dim=int(dmm_raw.get("emission_dim", 32)),
+            transition_dim=int(dmm_raw.get("transition_dim", 32)),
+            rnn_dim=int(dmm_raw.get("rnn_dim", 32)),
+            side_info_dim=int(dmm_raw.get("side_info_dim", 0)),
+            num_layers=int(dmm_raw.get("num_layers", 1)),
+            rnn_dropout_rate=float(dmm_raw.get("rnn_dropout_rate", 0.1)),
+            min_scale=float(dmm_raw.get("min_scale", 1e-4)),
+            num_epochs=int(dmm_raw.get("num_epochs", 150)),
+            mini_batch_size=int(dmm_raw.get("mini_batch_size", 20)),
+            learning_rate=float(dmm_raw.get("learning_rate", 3e-4)),
+            beta1=float(dmm_raw.get("beta1", 0.96)),
+            beta2=float(dmm_raw.get("beta2", 0.999)),
+            clip_norm=float(dmm_raw.get("clip_norm", 10.0)),
+            lr_decay=float(dmm_raw.get("lr_decay", 0.99996)),
+            weight_decay=float(dmm_raw.get("weight_decay", 2.0)),
+            min_annealing_factor=float(dmm_raw.get("min_annealing_factor", 0.2)),
+            annealing_epochs=int(dmm_raw.get("annealing_epochs", 1000)),
+            seed=int(dmm_raw.get("seed", 54)),
+        )
         vr_raw = raw.get("vol_ratio", {})
         vol_ratio_cfg = VolatilityRatioConfig(
             decay=float(vr_raw.get("decay", 0.79)),
@@ -393,6 +449,7 @@ class SideInfoComparisonConfig:
             spline=spline,
             bucketed_transition=bucketed,
             continuous_iohmm=continuous_iohmm,
+            dmm=dmm,
             vol_ratio=vol_ratio_cfg,
             seasonality=seasonality_cfg,
             cost_bps_per_turnover=float(raw.get("cost_bps_per_turnover", 0.0)),
@@ -602,12 +659,95 @@ class ContinuousSideInfoVariantWindow:
 
 
 @dataclass(frozen=True)
+class DmmVariantWindow:
+    """Per-window record for the DMM side-information benchmark."""
+
+    index: int
+    train_start: pd.Timestamp
+    train_end: pd.Timestamp
+    forecast_start: pd.Timestamp
+    forecast_end: pd.Timestamp
+    chosen_k: int
+    n_train_obs: int
+    n_forecast_obs: int
+    feature_identity: str
+    side_info_dim: int
+    num_epochs: int
+    mini_batch_size: int
+    learning_rate: float
+    beta1: float
+    beta2: float
+    clip_norm: float
+    lr_decay: float
+    weight_decay: float
+    min_annealing_factor: float
+    annealing_epochs: int
+    seed: int
+    final_loss: float
+    summary: pd.DataFrame
+
+    def __post_init__(self) -> None:
+        if self.index < 0:
+            raise ValueError(f"index must be non-negative, got {self.index}.")
+        if self.chosen_k < 2:
+            raise ValueError(f"chosen_k must be >= 2, got {self.chosen_k}.")
+        if self.n_train_obs < 1:
+            raise ValueError(f"n_train_obs must be >= 1, got {self.n_train_obs}.")
+        if self.n_forecast_obs < 2:
+            raise ValueError(
+                f"n_forecast_obs must be >= 2 to align signals; got {self.n_forecast_obs}."
+            )
+        if self.train_end < self.train_start:
+            raise ValueError("train_end must not precede train_start.")
+        if self.forecast_end < self.forecast_start:
+            raise ValueError("forecast_end must not precede forecast_start.")
+        if self.forecast_start <= self.train_end:
+            raise ValueError(
+                "forecast_start must be strictly after train_end; "
+                f"got train_end={self.train_end} forecast_start={self.forecast_start}."
+            )
+        if not isinstance(self.feature_identity, str) or not self.feature_identity:
+            raise ValueError("feature_identity must be a non-empty string.")
+        if self.side_info_dim < 1:
+            raise ValueError(f"side_info_dim must be >= 1, got {self.side_info_dim}.")
+        if self.num_epochs < 1:
+            raise ValueError(f"num_epochs must be >= 1, got {self.num_epochs}.")
+        if self.mini_batch_size < 1:
+            raise ValueError(f"mini_batch_size must be >= 1, got {self.mini_batch_size}.")
+        if self.annealing_epochs < 0:
+            raise ValueError(f"annealing_epochs must be >= 0, got {self.annealing_epochs}.")
+        if self.seed < 0:
+            raise ValueError(f"seed must be >= 0, got {self.seed}.")
+        for field_name, value in (
+            ("learning_rate", self.learning_rate),
+            ("clip_norm", self.clip_norm),
+            ("lr_decay", self.lr_decay),
+            ("weight_decay", self.weight_decay),
+            ("min_annealing_factor", self.min_annealing_factor),
+            ("beta1", self.beta1),
+            ("beta2", self.beta2),
+            ("final_loss", self.final_loss),
+        ):
+            numeric = float(value)
+            if not math.isfinite(numeric):
+                raise ValueError(f"{field_name} must be finite, got {numeric!r}.")
+        if not isinstance(self.summary, pd.DataFrame):
+            raise TypeError("summary must be a pd.DataFrame.")
+
+
+@dataclass(frozen=True)
 class SideInfoVariantResult:
     """Per-variant result of a side-information comparison."""
 
     variant: str
     chosen_k_per_window: tuple[int, ...]
-    windows: tuple[SideInfoVariantWindow | ContinuousSideInfoVariantWindow | WalkForwardWindow, ...]
+    windows: tuple[
+        SideInfoVariantWindow
+        | ContinuousSideInfoVariantWindow
+        | DmmVariantWindow
+        | WalkForwardWindow,
+        ...,
+    ]
     signal: pd.Series
     pre_cost_returns: pd.Series
     post_cost_returns: pd.Series
@@ -781,6 +921,16 @@ def run_side_info_comparison(
             baseline_windows=baseline_wf.windows,
         ),
     )
+    dmm_variant = _checkpointed_stage(
+        DMM_VARIANT,
+        checkpoint_path,
+        expected_type=SideInfoVariantResult,
+        factory=lambda: _run_dmm_variant(
+            returns=returns,
+            config=config,
+            baseline_windows=baseline_wf.windows,
+        ),
+    )
     default_hmm_variant = _checkpointed_stage(
         DEFAULT_HMM_VARIANT,
         checkpoint_path,
@@ -802,6 +952,7 @@ def run_side_info_comparison(
             VOLATILITY_RATIO_HMC_CONTINUOUS_VARIANT: vol_hmc_variant,
             SEASONALITY_HMC_CONTINUOUS_VARIANT: seasonality_hmc_variant,
             VOL_RATIO_SEASONALITY_HMC_CONTINUOUS_VARIANT: combined_hmc_variant,
+            DMM_VARIANT: dmm_variant,
             DEFAULT_HMM_VARIANT: default_hmm_variant,
         },
     )
@@ -1319,6 +1470,185 @@ def _run_default_hmm_variant(
     )
 
 
+def _run_dmm_variant(
+    *,
+    returns: pd.Series,
+    config: SideInfoComparisonConfig,
+    baseline_windows: tuple[WalkForwardWindow, ...],
+) -> SideInfoVariantResult:
+    """Run the DMM benchmark on the same windows as the baseline."""
+    if config.dmm.obs_dim != 1:
+        raise ValueError(f"config.dmm.obs_dim must be 1, got {config.dmm.obs_dim}.")
+
+    cost = config.cost_bps_per_turnover
+    bar_dates = returns.index.date
+
+    windows: list[DmmVariantWindow] = []
+    signal_parts: list[pd.Series] = []
+    pre_cost_parts: list[pd.Series] = []
+    post_cost_parts: list[pd.Series] = []
+    chosen_ks: list[int] = []
+    initial_position = 0
+    total_windows = len(baseline_windows)
+
+    for window_position, baseline_window in enumerate(baseline_windows, start=1):
+        window_start_time = time.monotonic()
+        train_mask = (bar_dates >= baseline_window.train_start.date()) & (
+            bar_dates <= baseline_window.train_end.date()
+        )
+        train_slice = returns.loc[train_mask]
+        effective_forecast = returns.loc[
+            baseline_window.forecast_start : baseline_window.forecast_end
+        ]
+        if effective_forecast.shape[0] < 2:
+            raise ValueError(
+                "each effective forecast window must contain at least 2 observations; "
+                f"window {baseline_window.index} has {effective_forecast.shape[0]}."
+            )
+
+        feature_full = _build_feature(
+            VOLATILITY_RATIO_VARIANT,
+            pd.concat([train_slice, effective_forecast]),
+            config,
+        )
+        feature_train = feature_full.reindex(train_slice.index)
+        feature_forecast = feature_full.reindex(effective_forecast.index)
+
+        forecast_has_nan = (
+            bool(feature_forecast.isna().any().any())
+            if isinstance(feature_forecast, pd.DataFrame)
+            else bool(feature_forecast.isna().any())
+        )
+        if forecast_has_nan:
+            raise ValueError(
+                f"forecast feature for variant {DMM_VARIANT!r} contains NaN in window "
+                f"{baseline_window.index}; increase h_days so the rolling window is "
+                "fully initialized before the forecast slice."
+            )
+
+        feature_train_clean = feature_train.dropna()
+        if feature_train_clean.shape[0] < 2:
+            raise ValueError(
+                f"variant {DMM_VARIANT!r} window {baseline_window.index} has fewer than 2 "
+                "finite training feature observations after dropping the NaN prefix."
+            )
+        train_returns_clean = train_slice.loc[feature_train_clean.index]
+        standardized_train_feature, standardized_forecast_feature = _standardize_feature_train_only(
+            feature_train_clean,
+            feature_forecast,
+        )
+
+        side_info_dim = _feature_side_info_dim(standardized_train_feature)
+        dmm_config = replace(config.dmm, side_info_dim=side_info_dim)
+        observations = torch.as_tensor(
+            train_returns_clean.to_numpy(dtype=np.float32).reshape(1, -1, 1),
+            dtype=torch.float32,
+        )
+        side_info = torch.as_tensor(
+            _feature_to_2d_numpy(standardized_train_feature).astype(np.float32, copy=False)[
+                None, :, :
+            ],
+            dtype=torch.float32,
+        )
+        seq_lengths = torch.tensor([train_returns_clean.shape[0]], dtype=torch.long)
+        fitted = fit_dmm(dmm_config, observations, side_info, seq_lengths)
+        expected_series = expected_next_returns_from_dmm(
+            fitted.model,
+            effective_forecast,
+            standardized_forecast_feature,
+        )
+
+        signal_scale: float | None = None
+        if config.signal_policy == "conviction_weighted":
+            train_expected = expected_next_returns_from_dmm(
+                fitted.model,
+                train_returns_clean,
+                standardized_train_feature,
+            )
+            signal_scale = conviction_scale_from_train_predictions(train_expected.to_numpy())
+
+        window_signal = build_signal(
+            expected_series,
+            policy=config.signal_policy,
+            threshold=config.signal_threshold,
+            initial_position=initial_position,
+            scale=signal_scale,
+        )
+        if config.signal_policy == "thresholded_hold":
+            initial_position = int(window_signal.iloc[-1])
+        window_pre_cost = align_signal_with_future_return(window_signal, effective_forecast)
+        window_post_cost = apply_turnover_cost(
+            window_pre_cost,
+            signal_turnover(window_signal),
+            cost_bps_per_turnover=cost,
+        )
+        window_summary = _summarize_return_modes(
+            window_pre_cost, window_post_cost, cost_bps_per_turnover=cost
+        )
+
+        signal_parts.append(window_signal)
+        pre_cost_parts.append(window_pre_cost)
+        post_cost_parts.append(window_post_cost)
+        chosen_ks.append(int(baseline_window.chosen_k))
+        windows.append(
+            DmmVariantWindow(
+                index=int(baseline_window.index),
+                train_start=train_slice.index.min(),
+                train_end=train_slice.index.max(),
+                forecast_start=effective_forecast.index.min(),
+                forecast_end=effective_forecast.index.max(),
+                chosen_k=int(baseline_window.chosen_k),
+                n_train_obs=int(train_slice.shape[0]),
+                n_forecast_obs=int(effective_forecast.shape[0]),
+                feature_identity=_DMM_FEATURE_IDENTITY,
+                side_info_dim=side_info_dim,
+                num_epochs=int(dmm_config.num_epochs),
+                mini_batch_size=int(dmm_config.mini_batch_size),
+                learning_rate=float(dmm_config.learning_rate),
+                beta1=float(dmm_config.beta1),
+                beta2=float(dmm_config.beta2),
+                clip_norm=float(dmm_config.clip_norm),
+                lr_decay=float(dmm_config.lr_decay),
+                weight_decay=float(dmm_config.weight_decay),
+                min_annealing_factor=float(dmm_config.min_annealing_factor),
+                annealing_epochs=int(dmm_config.annealing_epochs),
+                seed=int(dmm_config.seed),
+                final_loss=float(fitted.loss_history[-1]),
+                summary=window_summary,
+            )
+        )
+
+        elapsed = time.monotonic() - window_start_time
+        print(
+            f"[{DMM_VARIANT}] window {window_position}/{total_windows} "
+            f"index={int(baseline_window.index)} done in {elapsed:.1f}s "
+            f"final_loss={float(fitted.loss_history[-1]):.6f}",
+            file=sys.stderr,
+            flush=True,
+        )
+
+    combined_signal = pd.concat(signal_parts)
+    if config.signal_policy in _DISCRETE_SIGNAL_POLICIES:
+        combined_signal = combined_signal.astype(np.int8)
+    combined_signal.name = "signal"
+    pre_cost_returns = pd.concat(pre_cost_parts)
+    post_cost_returns = pd.concat(post_cost_parts)
+    summary = _summarize_return_modes(
+        pre_cost_returns, post_cost_returns, cost_bps_per_turnover=cost
+    )
+
+    return SideInfoVariantResult(
+        variant=DMM_VARIANT,
+        chosen_k_per_window=tuple(chosen_ks),
+        windows=tuple(windows),
+        signal=combined_signal,
+        pre_cost_returns=pre_cost_returns,
+        post_cost_returns=post_cost_returns,
+        summary=summary,
+        cost_bps_per_turnover=float(cost),
+    )
+
+
 def _bucket_boundaries_for_mode(
     *,
     spline_result: SplinePredictorResult,
@@ -1369,6 +1699,45 @@ def _build_feature(
             keys=["vol_ratio", "seasonality"],
         ).dropna()
     raise ValueError(f"unsupported variant {variant!r}.")
+
+
+def _standardize_feature_train_only(
+    train_feature: pd.Series | pd.DataFrame,
+    forecast_feature: pd.Series | pd.DataFrame,
+) -> tuple[pd.Series | pd.DataFrame, pd.Series | pd.DataFrame]:
+    """Z-score side information using train-slice moments only."""
+    if isinstance(train_feature, pd.DataFrame):
+        mean = train_feature.mean(axis=0)
+        std = train_feature.std(axis=0, ddof=0)
+        std = std.where(std > _MIN_STANDARDIZATION_STD, 1.0)
+        return (
+            (train_feature - mean) / std,
+            (forecast_feature - mean) / std,
+        )
+
+    mean = float(train_feature.mean())
+    std = float(train_feature.std(ddof=0))
+    if std <= _MIN_STANDARDIZATION_STD:
+        std = 1.0
+    return (
+        (train_feature - mean) / std,
+        (forecast_feature - mean) / std,
+    )
+
+
+def _feature_to_2d_numpy(feature: pd.Series | pd.DataFrame) -> np.ndarray:
+    values = np.asarray(feature.to_numpy(dtype=float), dtype=float)
+    if values.ndim == 1:
+        values = values[:, None]
+    if values.ndim != 2:
+        raise ValueError(f"feature must coerce to a 2-D array, got shape {values.shape}.")
+    if not np.all(np.isfinite(values)):
+        raise ValueError("feature values must contain only finite numbers.")
+    return values
+
+
+def _feature_side_info_dim(feature: pd.Series | pd.DataFrame) -> int:
+    return int(_feature_to_2d_numpy(feature).shape[1])
 
 
 def _dynamic_forward_expected_returns(
@@ -1711,6 +2080,21 @@ def _write_variant_log(path: Path, result: SideInfoVariantResult) -> None:
             record["ess_bulk_min"] = int(w.ess_bulk_min)
             record["posterior_mean_W"] = w.posterior_mean_W.tolist()
             record["posterior_mean_b"] = w.posterior_mean_b.tolist()
+        elif isinstance(w, DmmVariantWindow):
+            record["feature_identity"] = w.feature_identity
+            record["side_info_dim"] = int(w.side_info_dim)
+            record["num_epochs"] = int(w.num_epochs)
+            record["mini_batch_size"] = int(w.mini_batch_size)
+            record["learning_rate"] = _json_safe(w.learning_rate)
+            record["beta1"] = _json_safe(w.beta1)
+            record["beta2"] = _json_safe(w.beta2)
+            record["clip_norm"] = _json_safe(w.clip_norm)
+            record["lr_decay"] = _json_safe(w.lr_decay)
+            record["weight_decay"] = _json_safe(w.weight_decay)
+            record["min_annealing_factor"] = _json_safe(w.min_annealing_factor)
+            record["annealing_epochs"] = int(w.annealing_epochs)
+            record["seed"] = int(w.seed)
+            record["final_loss"] = _json_safe(w.final_loss)
         lines.append(json.dumps(record, sort_keys=True, allow_nan=False))
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 

--- a/src/hft_hmm/experiments/side_info_comparison.py
+++ b/src/hft_hmm/experiments/side_info_comparison.py
@@ -49,11 +49,10 @@ import uuid
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field, replace
 from pathlib import Path
-from typing import Any, Final, TypeVar
+from typing import TYPE_CHECKING, Any, Final, TypeVar
 
 import numpy as np
 import pandas as pd
-import torch
 import yaml
 from scipy.special import logsumexp
 
@@ -93,7 +92,6 @@ from hft_hmm.features.volatility_ratio import VolatilityRatioConfig, volatility_
 from hft_hmm.inference import filter_from_result
 from hft_hmm.inference.forward_filter import forward_filter
 from hft_hmm.models.default_hmm import fit_default_hmm
-from hft_hmm.models.dmm import DMMConfig, expected_next_returns_from_dmm, fit_dmm
 from hft_hmm.models.gaussian_hmm import GaussianHMMResult, GaussianHMMWrapper
 from hft_hmm.models.iohmm_approx import (
     BoundaryMode,
@@ -118,6 +116,12 @@ from hft_hmm.strategy.signals import (
     _DISCRETE_SIGNAL_POLICIES,
     _VALID_SIGNAL_POLICIES,
 )
+
+if TYPE_CHECKING:
+    # torch/pyro live behind the optional [dmm] extra; keep them out of the
+    # module import path so `import hft_hmm` stays torch-free. The DMM variant
+    # lazily imports them at call time.
+    from hft_hmm.models.dmm import DMMConfig
 
 __category__: Final[str] = EVALUATION_LAYER
 SIDE_INFO_COMPARISON_REFERENCE: Final[PaperReference] = reference(
@@ -166,6 +170,13 @@ _HMC_CONTINUOUS_VARIANTS: Final[tuple[str, ...]] = (
 # ---------------------------------------------------------------------------
 
 
+def _default_dmm_config() -> DMMConfig:
+    """Build the default DMMConfig, importing it lazily to keep torch optional."""
+    from hft_hmm.models.dmm import DMMConfig
+
+    return DMMConfig()
+
+
 @dataclass(frozen=True)
 class SideInfoComparisonConfig:
     """Recipe for one Gate H side-information comparison run.
@@ -185,7 +196,7 @@ class SideInfoComparisonConfig:
     spline: SplinePredictorConfig = field(default_factory=SplinePredictorConfig)
     bucketed_transition: BucketedTransitionConfig = field(default_factory=BucketedTransitionConfig)
     continuous_iohmm: ContinuousIOHMMConfig = field(default_factory=ContinuousIOHMMConfig)
-    dmm: DMMConfig = field(default_factory=DMMConfig)
+    dmm: DMMConfig = field(default_factory=_default_dmm_config)
     vol_ratio: VolatilityRatioConfig = field(default_factory=VolatilityRatioConfig)
     seasonality: SeasonalityConfig = field(default_factory=SeasonalityConfig)
     cost_bps_per_turnover: float = 0.0
@@ -220,8 +231,15 @@ class SideInfoComparisonConfig:
                 "continuous_iohmm must be a ContinuousIOHMMConfig, "
                 f"got {type(self.continuous_iohmm).__name__}."
             )
+        from hft_hmm.models.dmm import DMMConfig
+
         if not isinstance(self.dmm, DMMConfig):
             raise TypeError(f"dmm must be a DMMConfig, got {type(self.dmm).__name__}.")
+        if self.dmm.side_info_dim != 0:
+            raise ValueError(
+                "dmm.side_info_dim is derived from the side-info feature at runtime "
+                "(the DMM variant overrides it per window); set it to 0 in the config."
+            )
         if not isinstance(self.vol_ratio, VolatilityRatioConfig):
             raise TypeError(
                 "vol_ratio must be a VolatilityRatioConfig, "
@@ -405,6 +423,8 @@ class SideInfoComparisonConfig:
             rhat_threshold=float(ci_raw.get("rhat_threshold", 1.05)),
             ess_bulk_threshold=int(ci_raw.get("ess_bulk_threshold", 200)),
         )
+        from hft_hmm.models.dmm import DMMConfig
+
         dmm_raw = raw.get("dmm", {})
         if not isinstance(dmm_raw, Mapping):
             raise ValueError(f"dmm must be a mapping; got {type(dmm_raw).__name__}.")
@@ -1477,6 +1497,10 @@ def _run_dmm_variant(
     baseline_windows: tuple[WalkForwardWindow, ...],
 ) -> SideInfoVariantResult:
     """Run the DMM benchmark on the same windows as the baseline."""
+    import torch
+
+    from hft_hmm.models.dmm import expected_next_returns_from_dmm, fit_dmm
+
     if config.dmm.obs_dim != 1:
         raise ValueError(f"config.dmm.obs_dim must be 1, got {config.dmm.obs_dim}.")
 

--- a/tests/test_side_info_comparison.py
+++ b/tests/test_side_info_comparison.py
@@ -201,6 +201,20 @@ def test_config_rejects_invalid_subconfigs() -> None:
         SideInfoComparisonConfig(**base, dmm={"num_epochs": 2})  # type: ignore[arg-type]
 
 
+def test_config_rejects_nonzero_dmm_side_info_dim() -> None:
+    # dmm.side_info_dim is derived per window from the side-info feature; a non-zero
+    # config value is vestigial and would vary the comparison_id without changing the
+    # trained model, so it is rejected.
+    base = dict(
+        data=DataSourceConfig(kind="csv", path=str(SAMPLE_FIXTURE_CSV)),
+        frequency="1min",
+        walk_forward=WalkForwardConfig(h_days=10, t_days=2, retrain_every_days=2),
+        sha256=SAMPLE_FIXTURE_SHA256,
+    )
+    with pytest.raises(ValueError, match="side_info_dim"):
+        SideInfoComparisonConfig(**base, dmm=DMMConfig(side_info_dim=2))
+
+
 # ---------------------------------------------------------------------------
 # Runner integration
 # ---------------------------------------------------------------------------
@@ -732,11 +746,13 @@ def test_dmm_variant_standardizes_forecast_with_train_slice_stats_only(
         captured["forecast_side_info"] = side_info_arg.copy()
         return pd.Series(0.0, index=returns_arg.index, name="expected_next_returns")
 
+    # _run_dmm_variant lazily imports fit_dmm/expected_next_returns_from_dmm from
+    # hft_hmm.models.dmm at call time (to keep torch optional), so patch the source
+    # module. _build_feature stays a module-level symbol in side_info_comparison.
     monkeypatch.setattr(side_info_module, "_build_feature", fake_build_feature)
-    monkeypatch.setattr(side_info_module, "fit_dmm", fake_fit_dmm)
+    monkeypatch.setattr("hft_hmm.models.dmm.fit_dmm", fake_fit_dmm)
     monkeypatch.setattr(
-        side_info_module,
-        "expected_next_returns_from_dmm",
+        "hft_hmm.models.dmm.expected_next_returns_from_dmm",
         fake_expected_next_returns_from_dmm,
     )
 

--- a/tests/test_side_info_comparison.py
+++ b/tests/test_side_info_comparison.py
@@ -14,12 +14,16 @@ import numpy as np
 import pandas as pd
 import pytest
 
+pytest.importorskip("torch")
+pytest.importorskip("pyro")
+
 from hft_hmm.config.experiment_config import DataSourceConfig
 from hft_hmm.core import EVALUATION_LAYER, StateGrid, module_category
 from hft_hmm.experiments.side_info_comparison import (
     _CHECKPOINT_BASELINE_WF,
     BASELINE_VARIANT,
     DEFAULT_HMM_VARIANT,
+    DMM_VARIANT,
     EXPECTED_VARIANTS,
     SEASONALITY_HMC_CONTINUOUS_VARIANT,
     SEASONALITY_VARIANT,
@@ -27,6 +31,7 @@ from hft_hmm.experiments.side_info_comparison import (
     VOLATILITY_RATIO_HMC_CONTINUOUS_VARIANT,
     VOLATILITY_RATIO_VARIANT,
     ContinuousSideInfoVariantWindow,
+    DmmVariantWindow,
     SideInfoComparisonConfig,
     comparison_id,
     run_side_info_comparison,
@@ -35,6 +40,7 @@ from hft_hmm.experiments.walk_forward import WalkForwardConfig, walk_forward
 from hft_hmm.features.seasonality import SeasonalityConfig
 from hft_hmm.features.splines import SplinePredictorConfig
 from hft_hmm.features.volatility_ratio import VolatilityRatioConfig
+from hft_hmm.models.dmm import DMMConfig
 from hft_hmm.models.gaussian_hmm import GaussianHMMResult
 from hft_hmm.models.iohmm_approx import BucketedTransitionConfig, BucketedTransitionResult
 from hft_hmm.models.iohmm_continuous import ContinuousIOHMMConfig
@@ -42,8 +48,9 @@ from hft_hmm.models.iohmm_continuous import ContinuousIOHMMConfig
 side_info_module = importlib.import_module("hft_hmm.experiments.side_info_comparison")
 
 REPO_ROOT = Path(__file__).parent.parent
-FIXTURE_CSV = REPO_ROOT / "tests" / "fixtures" / "es_1min_month.csv"
-FIXTURE_SHA256 = "c81161b1932361e119483a37fa27b2e16ce39020bcfcc3e871812c5cb7a9ca34"
+SAMPLE_FIXTURE_CSV = REPO_ROOT / "tests" / "fixtures" / "es_1min_sample.csv"
+SAMPLE_FIXTURE_SHA256 = "aedc597af42b6ec9f454642b1c09afb61e30fe0df6f34b5d35f0e2175b3e7a45"
+MONTH_FIXTURE_SHA256 = "c81161b1932361e119483a37fa27b2e16ce39020bcfcc3e871812c5cb7a9ca34"
 EXAMPLE_CONFIG = REPO_ROOT / "configs" / "example_es_side_info_comparison.yaml"
 EXAMPLE_HMC_CONFIG = REPO_ROOT / "configs" / "example_es_databento_side_info_comparison_hmc.yaml"
 EXAMPLE_COMBINED_CONFIG = (
@@ -60,14 +67,14 @@ BUCKETED_VARIANTS = {
 }
 
 
-def _make_config(*, fixture_path: str = str(FIXTURE_CSV)) -> SideInfoComparisonConfig:
+def _make_config(*, fixture_path: str = str(SAMPLE_FIXTURE_CSV)) -> SideInfoComparisonConfig:
     return SideInfoComparisonConfig(
         data=DataSourceConfig(kind="csv", path=fixture_path),
-        frequency="1min",
+        frequency="5min",
         walk_forward=WalkForwardConfig(
-            h_days=10,
-            t_days=5,
-            retrain_every_days=5,
+            h_days=3,
+            t_days=1,
+            retrain_every_days=1,
             k_values=(2,),
             random_state=0,
             n_iter=100,
@@ -84,11 +91,31 @@ def _make_config(*, fixture_path: str = str(FIXTURE_CSV)) -> SideInfoComparisonC
             rhat_threshold=10.0,
             ess_bulk_threshold=1,
         ),
+        dmm=DMMConfig(
+            obs_dim=1,
+            z_dim=2,
+            emission_dim=4,
+            transition_dim=4,
+            rnn_dim=4,
+            num_layers=1,
+            rnn_dropout_rate=0.0,
+            num_epochs=2,
+            mini_batch_size=1,
+            learning_rate=5e-3,
+            beta1=0.9,
+            beta2=0.999,
+            clip_norm=5.0,
+            lr_decay=1.0,
+            weight_decay=0.0,
+            min_annealing_factor=0.2,
+            annealing_epochs=1,
+            seed=7,
+        ),
         vol_ratio=VolatilityRatioConfig(fast_window=50, slow_window=100),
         seasonality=SeasonalityConfig(bucket_minutes=1, exchange_tz="America/Chicago"),
         cost_bps_per_turnover=1.0,
         notes="test",
-        sha256=FIXTURE_SHA256,
+        sha256=SAMPLE_FIXTURE_SHA256,
     )
 
 
@@ -117,6 +144,8 @@ def test_config_yaml_round_trip_and_deterministic_id(tmp_path: Path) -> None:
     assert loaded.bucketed_transition.n_buckets == cfg.bucketed_transition.n_buckets
     assert loaded.bucketed_transition.boundary_mode == cfg.bucketed_transition.boundary_mode
     assert loaded.continuous_iohmm.num_samples == cfg.continuous_iohmm.num_samples
+    assert loaded.dmm.num_epochs == cfg.dmm.num_epochs
+    assert loaded.dmm.learning_rate == cfg.dmm.learning_rate
     assert SideInfoComparisonConfig.from_dict(loaded.to_dict()) == loaded
     assert loaded.vol_ratio.fast_window == cfg.vol_ratio.fast_window
     assert loaded.seasonality.bucket_minutes == cfg.seasonality.bucket_minutes
@@ -129,7 +158,7 @@ def test_config_yaml_round_trip_and_deterministic_id(tmp_path: Path) -> None:
 def test_example_config_loads() -> None:
     cfg = SideInfoComparisonConfig.from_yaml(EXAMPLE_CONFIG)
     assert cfg.frequency == "1min"
-    assert cfg.sha256 == FIXTURE_SHA256
+    assert cfg.sha256 == MONTH_FIXTURE_SHA256
     assert cfg.walk_forward.k_values == (2,)
     assert cfg.continuous_iohmm.num_samples == 12
 
@@ -157,10 +186,10 @@ def test_combined_example_config_round_trips() -> None:
 
 def test_config_rejects_invalid_subconfigs() -> None:
     base = dict(
-        data=DataSourceConfig(kind="csv", path=str(FIXTURE_CSV)),
+        data=DataSourceConfig(kind="csv", path=str(SAMPLE_FIXTURE_CSV)),
         frequency="1min",
         walk_forward=WalkForwardConfig(h_days=10, t_days=2, retrain_every_days=2),
-        sha256=FIXTURE_SHA256,
+        sha256=SAMPLE_FIXTURE_SHA256,
     )
     with pytest.raises(TypeError, match="bucketed_transition"):
         SideInfoComparisonConfig(**base, bucketed_transition={"n_buckets": 3})  # type: ignore[arg-type]
@@ -168,6 +197,8 @@ def test_config_rejects_invalid_subconfigs() -> None:
         SideInfoComparisonConfig(**base, spline={"n_knots": 5})  # type: ignore[arg-type]
     with pytest.raises(TypeError, match="continuous_iohmm"):
         SideInfoComparisonConfig(**base, continuous_iohmm={"num_samples": 8})  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="dmm"):
+        SideInfoComparisonConfig(**base, dmm={"num_epochs": 2})  # type: ignore[arg-type]
 
 
 # ---------------------------------------------------------------------------
@@ -200,6 +231,42 @@ def test_summary_metrics_are_finite_or_null(comparison_artifacts) -> None:
                 assert value is None or np.isfinite(
                     value
                 ), f"{variant}.{mode}.{column} is neither finite nor null: {value!r}"
+
+
+def test_dmm_variant_yields_valid_result(comparison_artifacts) -> None:
+    result = comparison_artifacts.result.variants[DMM_VARIANT]
+
+    assert result.variant == DMM_VARIANT
+    assert isinstance(result.signal, pd.Series)
+    assert isinstance(result.pre_cost_returns, pd.Series)
+    assert isinstance(result.post_cost_returns, pd.Series)
+    assert isinstance(result.summary, pd.DataFrame)
+    assert result.windows
+    assert all(isinstance(window, DmmVariantWindow) for window in result.windows)
+    assert len(result.signal) > len(result.pre_cost_returns) >= 1
+    assert result.pre_cost_returns.index.equals(result.post_cost_returns.index)
+
+
+def test_dmm_window_records_persist_training_settings(comparison_artifacts) -> None:
+    cfg = comparison_artifacts.config
+    result = comparison_artifacts.result.variants[DMM_VARIANT]
+    first_window = result.windows[0]
+
+    assert isinstance(first_window, DmmVariantWindow)
+    assert first_window.feature_identity == "volatility_ratio"
+    assert first_window.side_info_dim == 1
+    assert first_window.num_epochs == cfg.dmm.num_epochs
+    assert first_window.mini_batch_size == cfg.dmm.mini_batch_size
+    assert first_window.learning_rate == cfg.dmm.learning_rate
+    assert first_window.beta1 == cfg.dmm.beta1
+    assert first_window.beta2 == cfg.dmm.beta2
+    assert first_window.clip_norm == cfg.dmm.clip_norm
+    assert first_window.lr_decay == cfg.dmm.lr_decay
+    assert first_window.weight_decay == cfg.dmm.weight_decay
+    assert first_window.min_annealing_factor == cfg.dmm.min_annealing_factor
+    assert first_window.annealing_epochs == cfg.dmm.annealing_epochs
+    assert first_window.seed == cfg.dmm.seed
+    assert np.isfinite(first_window.final_loss)
 
 
 def test_baseline_summary_matches_direct_walk_forward(comparison_artifacts) -> None:
@@ -246,6 +313,11 @@ def test_artifact_layout_is_written(comparison_artifacts) -> None:
             assert "converged" in first_record
             assert "rhat_max" in first_record
             assert "ess_bulk_min" in first_record
+        elif variant == DMM_VARIANT:
+            assert first_record["feature_identity"] == "volatility_ratio"
+            assert first_record["side_info_dim"] == 1
+            assert first_record["num_epochs"] == comparison_artifacts.config.dmm.num_epochs
+            assert "final_loss" in first_record
 
 
 @pytest.mark.parametrize(
@@ -299,7 +371,7 @@ def test_quantile_boundary_mode_logs_effective_mode(
 
     artifacts = run_side_info_comparison(cfg, runs_root=tmp_path)
 
-    _no_bucket_variants = {BASELINE_VARIANT, DEFAULT_HMM_VARIANT} | HMC_VARIANTS
+    _no_bucket_variants = {BASELINE_VARIANT, DEFAULT_HMM_VARIANT, DMM_VARIANT} | HMC_VARIANTS
     for variant in EXPECTED_VARIANTS:
         records = [
             json.loads(line)
@@ -453,6 +525,16 @@ def test_checkpointing_resumes_after_simulated_crash(
 
     monkeypatch.setattr(side_info_module, "_run_side_info_variant", spy_run_side_info_variant)
 
+    dmm_variant_calls = 0
+    real_run_dmm_variant = side_info_module._run_dmm_variant
+
+    def spy_run_dmm_variant(**kwargs):
+        nonlocal dmm_variant_calls
+        dmm_variant_calls += 1
+        return real_run_dmm_variant(**kwargs)
+
+    monkeypatch.setattr(side_info_module, "_run_dmm_variant", spy_run_dmm_variant)
+
     default_hmm_calls = 0
 
     def spy_run_default_hmm_variant(**kwargs):
@@ -468,6 +550,7 @@ def test_checkpointing_resumes_after_simulated_crash(
     assert (
         side_info_variant_calls == []
     ), f"no side-info variant should be recomputed on resume, got {side_info_variant_calls!r}"
+    assert dmm_variant_calls == 0, "dmm variant must be loaded from checkpoint"
     assert default_hmm_calls == 1, "default_hmm was the only missing stage and must be recomputed"
     assert not checkpoint_dir.exists()
     assert _summary_payload(reference.directory) == _summary_payload(resumed.directory)
@@ -577,6 +660,107 @@ def test_dynamic_filter_uses_supplied_training_posterior_seed() -> None:
     assert expected[0] > 0.0
 
 
+def test_dmm_variant_standardizes_forecast_with_train_slice_stats_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from hft_hmm.experiments._data_loading import load_returns_from_source
+
+    cfg = _make_config()
+    returns = load_returns_from_source(cfg.data, frequency=cfg.frequency)
+    baseline = walk_forward(
+        returns,
+        cfg.walk_forward,
+        cost_bps_per_turnover=cfg.cost_bps_per_turnover,
+        signal_policy=cfg.signal_policy,
+        signal_threshold=cfg.signal_threshold,
+    )
+    baseline_window = baseline.windows[0]
+
+    bar_dates = returns.index.date
+    train_mask = (bar_dates >= baseline_window.train_start.date()) & (
+        bar_dates <= baseline_window.train_end.date()
+    )
+    train_slice = returns.loc[train_mask]
+    forecast_slice = returns.loc[baseline_window.forecast_start : baseline_window.forecast_end]
+    feature_index = pd.Index(train_slice.index.tolist() + forecast_slice.index.tolist())
+    feature_values = np.arange(feature_index.shape[0], dtype=float)
+    feature_values[0] = np.nan
+    feature = pd.Series(feature_values, index=feature_index, name="volatility_ratio")
+    feature_train = feature.reindex(train_slice.index)
+    feature_train_clean = feature_train.dropna()
+    feature_forecast = feature.reindex(forecast_slice.index)
+
+    train_mean = float(feature_train_clean.mean())
+    train_std = float(feature_train_clean.std(ddof=0))
+    expected_train_feature = (feature_train_clean - train_mean) / train_std
+    expected_forecast_feature = (feature_forecast - train_mean) / train_std
+
+    full_clean_feature = feature.dropna()
+    full_mean = float(full_clean_feature.mean())
+    full_std = float(full_clean_feature.std(ddof=0))
+    leaked_forecast_feature = (feature_forecast - full_mean) / full_std
+    assert not np.allclose(
+        expected_forecast_feature.to_numpy(),
+        leaked_forecast_feature.to_numpy(),
+    )
+
+    captured: dict[str, object] = {}
+
+    def fake_build_feature(
+        variant: str,
+        series: pd.Series,
+        config: SideInfoComparisonConfig,
+    ) -> pd.Series:
+        del config
+        assert variant == VOLATILITY_RATIO_VARIANT
+        return feature.reindex(series.index)
+
+    def fake_fit_dmm(config, observations, side_info, seq_lengths):
+        captured["config"] = config
+        captured["observations"] = observations.detach().cpu().numpy()
+        captured["side_info"] = side_info.detach().cpu().numpy()
+        captured["seq_lengths"] = seq_lengths.detach().cpu().numpy()
+        return type(
+            "FakeDmmFitResult",
+            (),
+            {"model": object(), "loss_history": (1.0, 0.5)},
+        )()
+
+    def fake_expected_next_returns_from_dmm(model, returns_arg, side_info_arg):
+        del model
+        captured["forecast_returns"] = returns_arg.copy()
+        captured["forecast_side_info"] = side_info_arg.copy()
+        return pd.Series(0.0, index=returns_arg.index, name="expected_next_returns")
+
+    monkeypatch.setattr(side_info_module, "_build_feature", fake_build_feature)
+    monkeypatch.setattr(side_info_module, "fit_dmm", fake_fit_dmm)
+    monkeypatch.setattr(
+        side_info_module,
+        "expected_next_returns_from_dmm",
+        fake_expected_next_returns_from_dmm,
+    )
+
+    result = side_info_module._run_dmm_variant(
+        returns=returns,
+        config=cfg,
+        baseline_windows=(baseline_window,),
+    )
+
+    assert result.variant == DMM_VARIANT
+    assert captured["config"].side_info_dim == 1
+    np.testing.assert_array_equal(captured["seq_lengths"], np.array([len(feature_train_clean)]))
+    np.testing.assert_allclose(
+        captured["observations"],
+        train_slice.loc[feature_train_clean.index].to_numpy(dtype=np.float32).reshape(1, -1, 1),
+    )
+    np.testing.assert_allclose(
+        captured["side_info"],
+        expected_train_feature.to_numpy(dtype=np.float32).reshape(1, -1, 1),
+    )
+    pd.testing.assert_series_equal(captured["forecast_returns"], forecast_slice)
+    pd.testing.assert_series_equal(captured["forecast_side_info"], expected_forecast_feature)
+
+
 # ---------------------------------------------------------------------------
 # CLI subprocess
 # ---------------------------------------------------------------------------
@@ -584,11 +768,13 @@ def test_dynamic_filter_uses_supplied_training_posterior_seed() -> None:
 
 def test_cli_runs_from_repo_root(tmp_path: Path) -> None:
     runs_root = tmp_path / "cli-runs"
+    config_path = tmp_path / "cli-side-info.yaml"
+    config_path.write_bytes(_make_config().to_yaml_bytes())
     completed = subprocess.run(
         [
             sys.executable,
             "scripts/run_side_info_comparison.py",
-            str(EXAMPLE_CONFIG.relative_to(REPO_ROOT)),
+            str(config_path),
             "--runs-root",
             str(runs_root),
             "--force",


### PR DESCRIPTION
## Summary
- register the new `dmm` variant in the existing side-info comparison dispatch and artifact flow
- add DMM config wiring, a DMM per-window result record, and a leakage-free train-only standardization path
- extend side-info comparison tests for DMM registration, persisted settings, and train-slice-only fit/standardization assertions

## Validation
- .venv/bin/ruff check src/hft_hmm/__init__.py src/hft_hmm/experiments/side_info_comparison.py tests/test_side_info_comparison.py
- .venv/bin/black --check src/hft_hmm/__init__.py src/hft_hmm/experiments/side_info_comparison.py tests/test_side_info_comparison.py
- .venv/bin/mypy src
- .venv/bin/pytest tests/test_side_info_comparison.py tests/test_dmm.py --no-cov


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Deep Markov Model (DMM) variant to the side-information comparison experiment, extending the set of model options and producing variant-specific outputs alongside existing comparisons.
  * Added DMM configuration support in the example YAML, including training, model, and dimensionality parameters.

* **Tests**
  * Expanded automated coverage for DMM, including result validity, per-window recorded training settings, artifact/log structure, checkpoint/resume behavior, and a regression to ensure standardization uses only training-slice statistics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->