### PR TITLE
P4: add DMM train/eval frequency split

### DIFF
--- a/configs/example_es_databento_side_info_comparison_dmm.yaml
+++ b/configs/example_es_databento_side_info_comparison_dmm.yaml
@@ -1,0 +1,79 @@
+bucketed_transition:
+  grid_size: 200
+  n_buckets: 3
+  smoothing: 1.0
+continuous_iohmm:
+  ess_bulk_threshold: 200
+  num_chains: 2
+  num_samples: 1000
+  num_warmup: 500
+  rhat_threshold: 1.05
+  seed: 0
+  target_accept_prob: 0.8
+# Cost is a post-cost diagnostic only. Paper-style model comparison should use
+# pre-cost Sharpe unless an execution model is explicitly specified.
+cost_bps_per_turnover: 1.0
+data:
+  end: null
+  kind: databento_parquet
+  path: data/databento/databento/ES_c_0_ohlcv-1m_2019-01-01_2024-12-31.parquet
+  start: null
+  symbol: ES.c.0
+dmm:
+  annealing_epochs: 1000
+  beta1: 0.96
+  beta2: 0.999
+  clip_norm: 10.0
+  emission_dim: 32
+  learning_rate: 0.0003
+  lr_decay: 0.99996
+  min_annealing_factor: 0.2
+  min_scale: 0.0001
+  mini_batch_size: 20
+  num_epochs: 150
+  num_layers: 1
+  obs_dim: 1
+  rnn_dim: 32
+  rnn_dropout_rate: 0.1
+  seed: 54
+  side_info_dim: 0
+  transition_dim: 32
+  weight_decay: 2.0
+  z_dim: 16
+eval_frequency: 1min
+frequency: 1min
+notes: Gate L DMM comparison template for Databento ES continuous-contract data.
+  The DMM is fit on 5-minute returns but forecast and evaluation remain at
+  1-minute frequency inside the shared walk-forward harness; that cross-frequency
+  forecast path is a deliberate engineering approximation documented in
+  side_info_comparison.py. This file is a P7-style run template, not a CI smoke
+  config.
+seasonality:
+  bucket_minutes: 1
+  exchange_tz: America/Chicago
+  normalize: true
+sha256: 519bc22f1db8f88e254db4c39c23657caa22709c45c6571d3dfc536d2d9731f7
+signal_policy: sign
+signal_threshold: 0.0
+spline:
+  degree: 3
+  demean: false
+  demean_grid_size: 1000
+  min_obs: 20
+  n_knots: 5
+train_frequency: 5min
+vol_ratio:
+  decay: 0.79
+  fast_window: 50
+  slow_window: 100
+walk_forward:
+  h_days: 23
+  k_values:
+  - 2
+  min_variance: 1.0e-08
+  n_iter: 100
+  random_state: 0
+  retrain_every_days: 20
+  t_days: 20
+  tol: 0.0001
+  variance_floor_policy: clamp

--- a/src/hft_hmm/experiments/side_info_comparison.py
+++ b/src/hft_hmm/experiments/side_info_comparison.py
@@ -19,6 +19,12 @@ variants are directly comparable on pre-cost signal quality:
 5. ``vol_ratio_seasonality_hmc_continuous`` — Gate Q combined-predictor
    continuous-parametric IOHMM using volatility-ratio and intraday-seasonality
    side information jointly.
+6. ``dmm`` — Deep Markov Model benchmark. When ``train_frequency`` is coarser
+   than ``eval_frequency`` the DMM is fit on the coarser return series but
+   still produces 1-step forecasts on the finer evaluation series. That
+   cross-frequency forecast path is a deliberate engineering approximation so
+   Gate L can compare 5-minute training against 1-minute evaluation inside the
+   existing walk-forward harness.
 
 The IOHMM-style conditioning is the engineering approximation from
 ``hft_hmm.models.iohmm_approx``: a bucket index is derived from the
@@ -129,6 +135,9 @@ SIDE_INFO_COMPARISON_REFERENCE: Final[PaperReference] = reference(
 )
 
 _VALID_FREQUENCIES: Final[tuple[str, ...]] = ("1min", "5min", "1D")
+_FREQUENCY_ORDER: Final[dict[str, int]] = {
+    frequency: index for index, frequency in enumerate(_VALID_FREQUENCIES)
+}
 _SHA256_HEX_LENGTH: Final[int] = 64
 
 BASELINE_VARIANT: Final[str] = "baseline"
@@ -185,7 +194,11 @@ class SideInfoComparisonConfig:
     by the baseline path so the baseline summary is bit-for-bit identical to a
     direct ``walk_forward`` invocation. ``spline``, ``bucketed_transition``,
     ``vol_ratio``, and ``seasonality`` parameterise the side-information
-    variants only — the baseline ignores them.
+    variants only — the baseline ignores them. ``eval_frequency`` overrides the
+    legacy top-level ``frequency`` for the comparison-wide load/eval cadence,
+    while ``train_frequency`` can coarsen the DMM fit cadence only. A coarser
+    DMM train frequency with a finer eval frequency is a deliberate Gate L
+    approximation documented in the module docstring.
 
     References: §4 side-information IOHMM comparison (evaluation layer)
     """
@@ -199,6 +212,8 @@ class SideInfoComparisonConfig:
     dmm: DMMConfig = field(default_factory=_default_dmm_config)
     vol_ratio: VolatilityRatioConfig = field(default_factory=VolatilityRatioConfig)
     seasonality: SeasonalityConfig = field(default_factory=SeasonalityConfig)
+    train_frequency: str | None = None
+    eval_frequency: str | None = None
     cost_bps_per_turnover: float = 0.0
     signal_policy: SignalPolicy = "sign"
     signal_threshold: float = 0.0
@@ -212,6 +227,14 @@ class SideInfoComparisonConfig:
             raise ValueError(
                 f"frequency must be one of {_VALID_FREQUENCIES}, got {self.frequency!r}."
             )
+        for field_name, value in (
+            ("train_frequency", self.train_frequency),
+            ("eval_frequency", self.eval_frequency),
+        ):
+            if value is not None and value not in _VALID_FREQUENCIES:
+                raise ValueError(
+                    f"{field_name} must be one of {_VALID_FREQUENCIES} or None, got {value!r}."
+                )
         if not isinstance(self.walk_forward, WalkForwardConfig):
             raise TypeError(
                 "walk_forward must be a WalkForwardConfig, "
@@ -268,6 +291,15 @@ class SideInfoComparisonConfig:
                 f"got {self.signal_threshold!r}."
             )
         object.__setattr__(self, "signal_threshold", signal_threshold)
+        if (
+            _FREQUENCY_ORDER[self.effective_train_frequency]
+            < _FREQUENCY_ORDER[self.effective_eval_frequency]
+        ):
+            raise ValueError(
+                "train_frequency must be the same as or coarser than eval_frequency; "
+                f"got train_frequency={self.effective_train_frequency!r} "
+                f"and eval_frequency={self.effective_eval_frequency!r}."
+            )
 
         if self.data.is_reproducible:
             if self.sha256 is None:
@@ -292,6 +324,14 @@ class SideInfoComparisonConfig:
     @property
     def is_reproducible(self) -> bool:
         return self.data.is_reproducible and self.sha256 is not None
+
+    @property
+    def effective_eval_frequency(self) -> str:
+        return self.eval_frequency or self.frequency
+
+    @property
+    def effective_train_frequency(self) -> str:
+        return self.train_frequency or self.effective_eval_frequency
 
     def to_dict(self) -> dict[str, Any]:
         wf = self.walk_forward
@@ -337,6 +377,7 @@ class SideInfoComparisonConfig:
                 "weight_decay": float(self.dmm.weight_decay),
                 "z_dim": int(self.dmm.z_dim),
             },
+            "eval_frequency": self.eval_frequency,
             "frequency": self.frequency,
             "notes": self.notes,
             "seasonality": {
@@ -370,6 +411,7 @@ class SideInfoComparisonConfig:
                 "tol": float(wf.tol),
                 "variance_floor_policy": str(wf.variance_floor_policy),
             },
+            "train_frequency": self.train_frequency,
         }
 
     @classmethod
@@ -472,6 +514,8 @@ class SideInfoComparisonConfig:
             dmm=dmm,
             vol_ratio=vol_ratio_cfg,
             seasonality=seasonality_cfg,
+            train_frequency=raw.get("train_frequency"),
+            eval_frequency=raw.get("eval_frequency"),
             cost_bps_per_turnover=float(raw.get("cost_bps_per_turnover", 0.0)),
             signal_policy=raw.get("signal_policy", "sign"),
             signal_threshold=float(raw.get("signal_threshold", 0.0)),
@@ -690,6 +734,8 @@ class DmmVariantWindow:
     chosen_k: int
     n_train_obs: int
     n_forecast_obs: int
+    train_frequency: str
+    eval_frequency: str
     feature_identity: str
     side_info_dim: int
     num_epochs: int
@@ -716,6 +762,21 @@ class DmmVariantWindow:
         if self.n_forecast_obs < 2:
             raise ValueError(
                 f"n_forecast_obs must be >= 2 to align signals; got {self.n_forecast_obs}."
+            )
+        if self.train_frequency not in _VALID_FREQUENCIES:
+            raise ValueError(
+                "train_frequency must be one of "
+                f"{_VALID_FREQUENCIES}, got {self.train_frequency!r}."
+            )
+        if self.eval_frequency not in _VALID_FREQUENCIES:
+            raise ValueError(
+                f"eval_frequency must be one of {_VALID_FREQUENCIES}, got {self.eval_frequency!r}."
+            )
+        if _FREQUENCY_ORDER[self.train_frequency] < _FREQUENCY_ORDER[self.eval_frequency]:
+            raise ValueError(
+                "train_frequency must be the same as or coarser than eval_frequency; "
+                f"got train_frequency={self.train_frequency!r} "
+                f"and eval_frequency={self.eval_frequency!r}."
             )
         if self.train_end < self.train_start:
             raise ValueError("train_end must not precede train_start.")
@@ -866,7 +927,12 @@ def run_side_info_comparison(
         checkpoint_path.mkdir(parents=True, exist_ok=True)
 
     reproducible = validate_data_reproducibility(config, stacklevel=3)
-    returns = load_returns_from_source(config.data, frequency=config.frequency)
+    eval_frequency = config.effective_eval_frequency
+    train_frequency = config.effective_train_frequency
+    returns = load_returns_from_source(config.data, frequency=eval_frequency)
+    dmm_train_returns = returns
+    if train_frequency != eval_frequency:
+        dmm_train_returns = load_returns_from_source(config.data, frequency=train_frequency)
 
     baseline_wf = _checkpointed_stage(
         _CHECKPOINT_BASELINE_WF,
@@ -947,6 +1013,7 @@ def run_side_info_comparison(
         expected_type=SideInfoVariantResult,
         factory=lambda: _run_dmm_variant(
             returns=returns,
+            train_returns=dmm_train_returns,
             config=config,
             baseline_windows=baseline_wf.windows,
         ),
@@ -1493,10 +1560,17 @@ def _run_default_hmm_variant(
 def _run_dmm_variant(
     *,
     returns: pd.Series,
+    train_returns: pd.Series,
     config: SideInfoComparisonConfig,
     baseline_windows: tuple[WalkForwardWindow, ...],
 ) -> SideInfoVariantResult:
-    """Run the DMM benchmark on the same windows as the baseline."""
+    """Run the DMM benchmark on the same windows as the baseline.
+
+    When ``train_returns`` is coarser than ``returns`` the DMM is fit on the
+    coarser series, but forecast features and predictions remain on the finer
+    evaluation series. This is the deliberate Gate L approximation described in
+    the config/module docs.
+    """
     import torch
 
     from hft_hmm.models.dmm import expected_next_returns_from_dmm, fit_dmm
@@ -1505,7 +1579,8 @@ def _run_dmm_variant(
         raise ValueError(f"config.dmm.obs_dim must be 1, got {config.dmm.obs_dim}.")
 
     cost = config.cost_bps_per_turnover
-    bar_dates = returns.index.date
+    eval_frequency = config.effective_eval_frequency
+    train_frequency = config.effective_train_frequency
 
     windows: list[DmmVariantWindow] = []
     signal_parts: list[pd.Series] = []
@@ -1517,26 +1592,47 @@ def _run_dmm_variant(
 
     for window_position, baseline_window in enumerate(baseline_windows, start=1):
         window_start_time = time.monotonic()
-        train_mask = (bar_dates >= baseline_window.train_start.date()) & (
-            bar_dates <= baseline_window.train_end.date()
-        )
-        train_slice = returns.loc[train_mask]
+        train_slice = returns.loc[baseline_window.train_start : baseline_window.train_end]
         effective_forecast = returns.loc[
             baseline_window.forecast_start : baseline_window.forecast_end
         ]
+        train_fit_slice = train_returns.loc[baseline_window.train_start : baseline_window.train_end]
         if effective_forecast.shape[0] < 2:
             raise ValueError(
                 "each effective forecast window must contain at least 2 observations; "
                 f"window {baseline_window.index} has {effective_forecast.shape[0]}."
             )
+        if train_fit_slice.shape[0] < 2:
+            raise ValueError(
+                f"variant {DMM_VARIANT!r} window {baseline_window.index} has fewer than 2 "
+                f"training observations at train_frequency={train_frequency!r}."
+            )
 
-        feature_full = _build_feature(
+        train_feature = _build_feature(
+            VOLATILITY_RATIO_VARIANT,
+            train_fit_slice,
+            config,
+        )
+        train_feature_clean = train_feature.dropna()
+        if train_feature_clean.shape[0] < 2:
+            raise ValueError(
+                f"variant {DMM_VARIANT!r} window {baseline_window.index} has fewer than 2 "
+                "finite training feature observations after dropping the NaN prefix "
+                f"at train_frequency={train_frequency!r}."
+            )
+        train_returns_clean = train_fit_slice.loc[train_feature_clean.index]
+        standardized_train_feature, _ = _standardize_feature_train_only(
+            train_feature_clean,
+            train_feature_clean,
+        )
+
+        eval_feature_full = _build_feature(
             VOLATILITY_RATIO_VARIANT,
             pd.concat([train_slice, effective_forecast]),
             config,
         )
-        feature_train = feature_full.reindex(train_slice.index)
-        feature_forecast = feature_full.reindex(effective_forecast.index)
+        feature_train = eval_feature_full.reindex(train_slice.index)
+        feature_forecast = eval_feature_full.reindex(effective_forecast.index)
 
         forecast_has_nan = (
             bool(feature_forecast.isna().any().any())
@@ -1550,16 +1646,19 @@ def _run_dmm_variant(
                 "fully initialized before the forecast slice."
             )
 
-        feature_train_clean = feature_train.dropna()
-        if feature_train_clean.shape[0] < 2:
+        eval_feature_train_clean = feature_train.dropna()
+        if eval_feature_train_clean.shape[0] < 2:
             raise ValueError(
                 f"variant {DMM_VARIANT!r} window {baseline_window.index} has fewer than 2 "
-                "finite training feature observations after dropping the NaN prefix."
+                "finite evaluation-frequency training feature observations after dropping "
+                "the NaN prefix."
             )
-        train_returns_clean = train_slice.loc[feature_train_clean.index]
-        standardized_train_feature, standardized_forecast_feature = _standardize_feature_train_only(
-            feature_train_clean,
-            feature_forecast,
+        eval_train_returns_clean = train_slice.loc[eval_feature_train_clean.index]
+        standardized_eval_train_feature, standardized_forecast_feature = (
+            _standardize_feature_train_only(
+                eval_feature_train_clean,
+                feature_forecast,
+            )
         )
 
         side_info_dim = _feature_side_info_dim(standardized_train_feature)
@@ -1586,8 +1685,8 @@ def _run_dmm_variant(
         if config.signal_policy == "conviction_weighted":
             train_expected = expected_next_returns_from_dmm(
                 fitted.model,
-                train_returns_clean,
-                standardized_train_feature,
+                eval_train_returns_clean,
+                standardized_eval_train_feature,
             )
             signal_scale = conviction_scale_from_train_predictions(train_expected.to_numpy())
 
@@ -1617,13 +1716,15 @@ def _run_dmm_variant(
         windows.append(
             DmmVariantWindow(
                 index=int(baseline_window.index),
-                train_start=train_slice.index.min(),
-                train_end=train_slice.index.max(),
+                train_start=train_fit_slice.index.min(),
+                train_end=train_fit_slice.index.max(),
                 forecast_start=effective_forecast.index.min(),
                 forecast_end=effective_forecast.index.max(),
                 chosen_k=int(baseline_window.chosen_k),
-                n_train_obs=int(train_slice.shape[0]),
+                n_train_obs=int(train_fit_slice.shape[0]),
                 n_forecast_obs=int(effective_forecast.shape[0]),
+                train_frequency=train_frequency,
+                eval_frequency=eval_frequency,
                 feature_identity=_DMM_FEATURE_IDENTITY,
                 side_info_dim=side_info_dim,
                 num_epochs=int(dmm_config.num_epochs),
@@ -1646,6 +1747,7 @@ def _run_dmm_variant(
         print(
             f"[{DMM_VARIANT}] window {window_position}/{total_windows} "
             f"index={int(baseline_window.index)} done in {elapsed:.1f}s "
+            f"train_frequency={train_frequency} eval_frequency={eval_frequency} "
             f"final_loss={float(fitted.loss_history[-1]):.6f}",
             file=sys.stderr,
             flush=True,
@@ -2018,7 +2120,7 @@ def _write_summary(
     payload: dict[str, Any] = {
         "comparison_id": cmp_id,
         "reproducible": reproducible,
-        "frequency": config.frequency,
+        "frequency": config.effective_eval_frequency,
         "cost_bps_per_turnover": float(config.cost_bps_per_turnover),
         "metric_interpretation": {
             "pre-cost": (
@@ -2105,6 +2207,8 @@ def _write_variant_log(path: Path, result: SideInfoVariantResult) -> None:
             record["posterior_mean_W"] = w.posterior_mean_W.tolist()
             record["posterior_mean_b"] = w.posterior_mean_b.tolist()
         elif isinstance(w, DmmVariantWindow):
+            record["train_frequency"] = w.train_frequency
+            record["eval_frequency"] = w.eval_frequency
             record["feature_identity"] = w.feature_identity
             record["side_info_dim"] = int(w.side_info_dim)
             record["num_epochs"] = int(w.num_epochs)

--- a/tests/test_side_info_comparison.py
+++ b/tests/test_side_info_comparison.py
@@ -56,6 +56,7 @@ EXAMPLE_HMC_CONFIG = REPO_ROOT / "configs" / "example_es_databento_side_info_com
 EXAMPLE_COMBINED_CONFIG = (
     REPO_ROOT / "configs" / "example_es_databento_side_info_comparison_combined.yaml"
 )
+EXAMPLE_DMM_CONFIG = REPO_ROOT / "configs" / "example_es_databento_side_info_comparison_dmm.yaml"
 HMC_VARIANTS = {
     VOLATILITY_RATIO_HMC_CONTINUOUS_VARIANT,
     SEASONALITY_HMC_CONTINUOUS_VARIANT,
@@ -67,10 +68,16 @@ BUCKETED_VARIANTS = {
 }
 
 
-def _make_config(*, fixture_path: str = str(SAMPLE_FIXTURE_CSV)) -> SideInfoComparisonConfig:
+def _make_config(
+    *,
+    fixture_path: str = str(SAMPLE_FIXTURE_CSV),
+    frequency: str = "5min",
+    train_frequency: str | None = None,
+    eval_frequency: str | None = None,
+) -> SideInfoComparisonConfig:
     return SideInfoComparisonConfig(
         data=DataSourceConfig(kind="csv", path=fixture_path),
-        frequency="5min",
+        frequency=frequency,
         walk_forward=WalkForwardConfig(
             h_days=3,
             t_days=1,
@@ -113,6 +120,8 @@ def _make_config(*, fixture_path: str = str(SAMPLE_FIXTURE_CSV)) -> SideInfoComp
         ),
         vol_ratio=VolatilityRatioConfig(fast_window=50, slow_window=100),
         seasonality=SeasonalityConfig(bucket_minutes=1, exchange_tz="America/Chicago"),
+        train_frequency=train_frequency,
+        eval_frequency=eval_frequency,
         cost_bps_per_turnover=1.0,
         notes="test",
         sha256=SAMPLE_FIXTURE_SHA256,
@@ -134,12 +143,16 @@ def test_side_info_comparison_module_is_evaluation_layer() -> None:
 
 
 def test_config_yaml_round_trip_and_deterministic_id(tmp_path: Path) -> None:
-    cfg = _make_config()
+    cfg = _make_config(frequency="5min", train_frequency="5min", eval_frequency="1min")
     yaml_path = tmp_path / "comparison.yaml"
     yaml_path.write_bytes(cfg.to_yaml_bytes())
     loaded = SideInfoComparisonConfig.from_yaml(yaml_path)
 
     assert loaded.frequency == cfg.frequency
+    assert loaded.train_frequency == cfg.train_frequency
+    assert loaded.eval_frequency == cfg.eval_frequency
+    assert loaded.effective_train_frequency == "5min"
+    assert loaded.effective_eval_frequency == "1min"
     assert loaded.walk_forward.h_days == cfg.walk_forward.h_days
     assert loaded.bucketed_transition.n_buckets == cfg.bucketed_transition.n_buckets
     assert loaded.bucketed_transition.boundary_mode == cfg.bucketed_transition.boundary_mode
@@ -184,6 +197,19 @@ def test_combined_example_config_round_trips() -> None:
     assert SideInfoComparisonConfig.from_dict(raw) == cfg
 
 
+def test_dmm_example_config_round_trips() -> None:
+    cfg = SideInfoComparisonConfig.from_yaml(EXAMPLE_DMM_CONFIG)
+    raw = cfg.to_dict()
+
+    assert cfg.frequency == "1min"
+    assert cfg.eval_frequency == "1min"
+    assert cfg.train_frequency == "5min"
+    assert cfg.effective_eval_frequency == "1min"
+    assert cfg.effective_train_frequency == "5min"
+    assert cfg.dmm.num_epochs == 150
+    assert SideInfoComparisonConfig.from_dict(raw) == cfg
+
+
 def test_config_rejects_invalid_subconfigs() -> None:
     base = dict(
         data=DataSourceConfig(kind="csv", path=str(SAMPLE_FIXTURE_CSV)),
@@ -215,6 +241,11 @@ def test_config_rejects_nonzero_dmm_side_info_dim() -> None:
         SideInfoComparisonConfig(**base, dmm=DMMConfig(side_info_dim=2))
 
 
+def test_config_rejects_train_frequency_finer_than_eval_frequency() -> None:
+    with pytest.raises(ValueError, match="train_frequency must be the same as or coarser"):
+        _make_config(frequency="5min", train_frequency="1min", eval_frequency="5min")
+
+
 # ---------------------------------------------------------------------------
 # Runner integration
 # ---------------------------------------------------------------------------
@@ -224,6 +255,15 @@ def test_config_rejects_nonzero_dmm_side_info_dim() -> None:
 def comparison_artifacts(tmp_path_factory):
     cfg = _make_config()
     return run_side_info_comparison(cfg, runs_root=tmp_path_factory.mktemp("side-info-runs"))
+
+
+@pytest.fixture(scope="module")
+def freq_split_comparison_artifacts(tmp_path_factory):
+    cfg = _make_config(frequency="1min", train_frequency="5min", eval_frequency="1min")
+    return run_side_info_comparison(
+        cfg,
+        runs_root=tmp_path_factory.mktemp("side-info-freq-split-runs"),
+    )
 
 
 def test_runner_produces_all_expected_variants(comparison_artifacts) -> None:
@@ -283,6 +323,25 @@ def test_dmm_window_records_persist_training_settings(comparison_artifacts) -> N
     assert np.isfinite(first_window.final_loss)
 
 
+def test_dmm_freq_split_run_records_effective_frequencies(freq_split_comparison_artifacts) -> None:
+    result = freq_split_comparison_artifacts.result.variants[DMM_VARIANT]
+    summary = json.loads((freq_split_comparison_artifacts.directory / "summary.json").read_text())
+
+    assert result.windows
+    assert all(isinstance(window, DmmVariantWindow) for window in result.windows)
+    assert {window.train_frequency for window in result.windows} == {"5min"}
+    assert {window.eval_frequency for window in result.windows} == {"1min"}
+    assert summary["frequency"] == "1min"
+
+    first_record = json.loads(
+        (freq_split_comparison_artifacts.directory / f"{DMM_VARIANT}.log.jsonl")
+        .read_text()
+        .splitlines()[0]
+    )
+    assert first_record["train_frequency"] == "5min"
+    assert first_record["eval_frequency"] == "1min"
+
+
 def test_baseline_summary_matches_direct_walk_forward(comparison_artifacts) -> None:
     cfg = comparison_artifacts.config
     from hft_hmm.experiments._data_loading import load_returns_from_source
@@ -328,6 +387,14 @@ def test_artifact_layout_is_written(comparison_artifacts) -> None:
             assert "rhat_max" in first_record
             assert "ess_bulk_min" in first_record
         elif variant == DMM_VARIANT:
+            assert (
+                first_record["train_frequency"]
+                == comparison_artifacts.config.effective_train_frequency
+            )
+            assert (
+                first_record["eval_frequency"]
+                == comparison_artifacts.config.effective_eval_frequency
+            )
             assert first_record["feature_identity"] == "volatility_ratio"
             assert first_record["side_info_dim"] == 1
             assert first_record["num_epochs"] == comparison_artifacts.config.dmm.num_epochs
@@ -674,13 +741,14 @@ def test_dynamic_filter_uses_supplied_training_posterior_seed() -> None:
     assert expected[0] > 0.0
 
 
-def test_dmm_variant_standardizes_forecast_with_train_slice_stats_only(
+def test_dmm_variant_uses_train_frequency_slice_and_eval_frequency_standardization_without_leakage(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from hft_hmm.experiments._data_loading import load_returns_from_source
 
-    cfg = _make_config()
-    returns = load_returns_from_source(cfg.data, frequency=cfg.frequency)
+    cfg = _make_config(frequency="1min", train_frequency="5min", eval_frequency="1min")
+    returns = load_returns_from_source(cfg.data, frequency=cfg.effective_eval_frequency)
+    train_returns = load_returns_from_source(cfg.data, frequency=cfg.effective_train_frequency)
     baseline = walk_forward(
         returns,
         cfg.walk_forward,
@@ -690,26 +758,37 @@ def test_dmm_variant_standardizes_forecast_with_train_slice_stats_only(
     )
     baseline_window = baseline.windows[0]
 
-    bar_dates = returns.index.date
-    train_mask = (bar_dates >= baseline_window.train_start.date()) & (
-        bar_dates <= baseline_window.train_end.date()
-    )
-    train_slice = returns.loc[train_mask]
+    train_slice = returns.loc[baseline_window.train_start : baseline_window.train_end]
     forecast_slice = returns.loc[baseline_window.forecast_start : baseline_window.forecast_end]
-    feature_index = pd.Index(train_slice.index.tolist() + forecast_slice.index.tolist())
-    feature_values = np.arange(feature_index.shape[0], dtype=float)
-    feature_values[0] = np.nan
-    feature = pd.Series(feature_values, index=feature_index, name="volatility_ratio")
-    feature_train = feature.reindex(train_slice.index)
+    train_fit_slice = train_returns.loc[baseline_window.train_start : baseline_window.train_end]
+    assert train_fit_slice.index.max() <= baseline_window.train_end
+    assert train_fit_slice.index.max() < baseline_window.forecast_start
+
+    train_feature_values = np.arange(train_fit_slice.shape[0], dtype=float)
+    train_feature_values[0] = np.nan
+    train_feature = pd.Series(
+        train_feature_values,
+        index=train_fit_slice.index,
+        name="volatility_ratio",
+    )
+    train_feature_clean = train_feature.dropna()
+    expected_train_mean = float(train_feature_clean.mean())
+    expected_train_std = float(train_feature_clean.std(ddof=0))
+    expected_train_feature = (train_feature_clean - expected_train_mean) / expected_train_std
+
+    eval_feature_index = pd.Index(train_slice.index.tolist() + forecast_slice.index.tolist())
+    eval_feature_values = np.arange(eval_feature_index.shape[0], dtype=float)
+    eval_feature_values[0] = np.nan
+    eval_feature = pd.Series(eval_feature_values, index=eval_feature_index, name="volatility_ratio")
+    feature_train = eval_feature.reindex(train_slice.index)
     feature_train_clean = feature_train.dropna()
-    feature_forecast = feature.reindex(forecast_slice.index)
+    feature_forecast = eval_feature.reindex(forecast_slice.index)
 
-    train_mean = float(feature_train_clean.mean())
-    train_std = float(feature_train_clean.std(ddof=0))
-    expected_train_feature = (feature_train_clean - train_mean) / train_std
-    expected_forecast_feature = (feature_forecast - train_mean) / train_std
+    eval_train_mean = float(feature_train_clean.mean())
+    eval_train_std = float(feature_train_clean.std(ddof=0))
+    expected_forecast_feature = (feature_forecast - eval_train_mean) / eval_train_std
 
-    full_clean_feature = feature.dropna()
+    full_clean_feature = eval_feature.dropna()
     full_mean = float(full_clean_feature.mean())
     full_std = float(full_clean_feature.std(ddof=0))
     leaked_forecast_feature = (feature_forecast - full_mean) / full_std
@@ -727,7 +806,11 @@ def test_dmm_variant_standardizes_forecast_with_train_slice_stats_only(
     ) -> pd.Series:
         del config
         assert variant == VOLATILITY_RATIO_VARIANT
-        return feature.reindex(series.index)
+        if series.index.equals(train_fit_slice.index):
+            return train_feature
+        if series.index.equals(eval_feature_index):
+            return eval_feature
+        raise AssertionError(f"unexpected feature series index for DMM test: {series.index!r}")
 
     def fake_fit_dmm(config, observations, side_info, seq_lengths):
         captured["config"] = config
@@ -758,16 +841,20 @@ def test_dmm_variant_standardizes_forecast_with_train_slice_stats_only(
 
     result = side_info_module._run_dmm_variant(
         returns=returns,
+        train_returns=train_returns,
         config=cfg,
         baseline_windows=(baseline_window,),
     )
 
     assert result.variant == DMM_VARIANT
+    assert isinstance(result.windows[0], DmmVariantWindow)
+    assert result.windows[0].train_frequency == "5min"
+    assert result.windows[0].eval_frequency == "1min"
     assert captured["config"].side_info_dim == 1
-    np.testing.assert_array_equal(captured["seq_lengths"], np.array([len(feature_train_clean)]))
+    np.testing.assert_array_equal(captured["seq_lengths"], np.array([len(train_feature_clean)]))
     np.testing.assert_allclose(
         captured["observations"],
-        train_slice.loc[feature_train_clean.index].to_numpy(dtype=np.float32).reshape(1, -1, 1),
+        train_fit_slice.loc[train_feature_clean.index].to_numpy(dtype=np.float32).reshape(1, -1, 1),
     )
     np.testing.assert_allclose(
         captured["side_info"],


### PR DESCRIPTION
## Summary
- add explicit train/eval frequency fields to the side-info comparison config with leakage-safe validation
- load a separate coarser DMM training series when requested while keeping comparison evaluation on the fine series
- record effective DMM train/eval frequencies in per-window artifacts and add the Databento DMM template config plus frequency-split tests

## Validation
- .venv/bin/ruff check src/hft_hmm/experiments/side_info_comparison.py tests/test_side_info_comparison.py
- timeout 60s .venv/bin/black --check src/hft_hmm/experiments/side_info_comparison.py tests/test_side_info_comparison.py
- .venv/bin/mypy src
- .venv/bin/pytest tests/test_dmm.py --no-cov
- timeout 900s .venv/bin/pytest tests/test_side_info_comparison.py --no-cov > /tmp/test_side_info_p4.log 2>&1
- .venv/bin/pytest tests/test_repro.py tail cases plus direct repro CLI path were exercised; the full file stalls in this runner after the side-info CLI case begins, but the changed side-info comparison path itself was validated separately

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added example configuration template for DMM Databento continuous-contract comparisons.
  * Support for separate training and evaluation frequencies, enabling flexible model fitting and evaluation at different cadences.

* **Tests**
  * Enhanced test coverage for multi-frequency configurations and DMM model validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->