### PR TITLE
Gate L P5+P6: DMM reproducibility wiring + latent-trajectory figure

### DIFF
--- a/scripts/repro.py
+++ b/scripts/repro.py
@@ -6,9 +6,18 @@ selects the standalone predictor runner. In standalone predictor mode, HMM-only
 ``walk_forward`` fields are not consumed: ``min_variance``,
 ``variance_floor_policy``, ``k_values``, ``n_iter``, and ``tol``.
 
+For DMM side-information comparisons, ``config.dmm.seed`` seeds Python's
+``random`` module, NumPy, Torch, and Pyro inside ``fit_dmm()``. The
+reproducibility guarantee is intentionally stated as a tolerance band rather
+than bit-for-bit identity because SVI can drift across BLAS threading setups.
+To pin the documented contract, run the script with ``--torch-threads 1``;
+seeded DMM runs should then agree within ``1e-6`` absolute tolerance on the
+reported metrics.
+
 Usage:
     python scripts/repro.py configs/example_es_csv.yaml
     python scripts/repro.py my_config.yaml --force --runs-root custom_runs
+    python scripts/repro.py my_dmm_config.yaml --torch-threads 1
 """
 
 from __future__ import annotations
@@ -53,11 +62,26 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Overwrite an existing run directory with the same run_id.",
     )
+    parser.add_argument(
+        "--torch-threads",
+        type=int,
+        default=None,
+        help=(
+            "Pin torch CPU threads before dispatch. Use 1 for the documented "
+            "DMM reproducibility guarantee."
+        ),
+    )
     args = parser.parse_args(argv)
 
     if not args.config.exists():
         print(f"Config not found: {args.config}", file=sys.stderr)
         return 2
+    if args.torch_threads is not None and args.torch_threads < 1:
+        parser.error("--torch-threads must be >= 1.")
+
+    if args.torch_threads is not None:
+        if not _set_torch_threads(args.torch_threads):
+            return 2
 
     raw = yaml.safe_load(args.config.read_text(encoding="utf-8"))
     if not isinstance(raw, dict):
@@ -101,6 +125,20 @@ def _warn_on_ignored_hmm_keys(raw: dict[str, object]) -> None:
         UserWarning,
         stacklevel=2,
     )
+
+
+def _set_torch_threads(num_threads: int) -> bool:
+    try:
+        import torch
+    except ImportError:
+        print(
+            "--torch-threads requires torch to be installed in the current environment.",
+            file=sys.stderr,
+        )
+        return False
+
+    torch.set_num_threads(num_threads)
+    return True
 
 
 if __name__ == "__main__":

--- a/src/hft_hmm/__init__.py
+++ b/src/hft_hmm/__init__.py
@@ -115,6 +115,7 @@ from hft_hmm.selection import (
     bic,
     compare_state_counts,
     count_gaussian_hmm_parameters,
+    plot_dmm_filtered_latent_trajectory,
     plot_selection_curves,
 )
 from hft_hmm.strategy import (
@@ -215,6 +216,7 @@ __all__ = [
     "load_yfinance_market_data",
     "max_drawdown",
     "module_category",
+    "plot_dmm_filtered_latent_trajectory",
     "plot_selection_curves",
     "reference",
     "resample_prices",

--- a/src/hft_hmm/models/dmm.py
+++ b/src/hft_hmm/models/dmm.py
@@ -25,10 +25,12 @@ Variable-length mini-batches are represented as padded tensors plus
 ``seq_lengths``. The model and guide preserve the P0 spike's masking strategy so
 padded timesteps do not contribute to latent or observation log-probability.
 The ``fit_dmm()`` entry point seeds Python's ``random`` module, NumPy, Torch,
-and Pyro from ``DMMConfig.seed``. On CPU, the unit tests pin Torch to one
-thread and assert repeated SVI fits match within an absolute loss tolerance of
-``1e-6``; reproducibility is therefore documented as within-tolerance rather
-than bit-for-bit identical across all environments.
+and Pyro from ``DMMConfig.seed``. The reproducibility contract for the SVI path
+assumes a single CPU Torch thread: the tests pin ``torch.set_num_threads(1)``
+and assert repeated seeded fits match within ``1e-6`` absolute tolerance.
+Across other BLAS threading setups the same seed can still drift slightly, so
+the DMM is documented as reproducible within tolerance rather than bit-for-bit
+identical across all environments.
 
 References: Krishnan et al. (2017) §3-4
 """
@@ -77,6 +79,8 @@ DEFAULT_WEIGHT_DECAY: Final[float] = 2.0
 DEFAULT_MIN_ANNEALING_FACTOR: Final[float] = 0.2
 DEFAULT_ANNEALING_EPOCHS: Final[int] = 1000
 DEFAULT_SEED: Final[int] = 54
+SINGLE_THREAD_REPRO_TORCH_THREADS: Final[int] = 1
+SINGLE_THREAD_REPRO_ABS_TOLERANCE: Final[float] = 1e-6
 
 
 @dataclass(frozen=True)
@@ -89,10 +93,11 @@ class DMMConfig:
 
     Reproducibility note: :func:`fit_dmm` seeds Python's ``random`` module,
     NumPy, Torch, and Pyro from ``seed`` before constructing the model and SVI
-    objects. The unit tests pin Torch to one CPU thread and assert repeated loss
-    histories agree within ``1e-6`` absolute tolerance; callers should treat the
-    fit as reproducible within tolerance rather than exactly identical across
-    machines or BLAS threading setups.
+    objects. The documented guarantee assumes ``torch.set_num_threads(1)``:
+    repeated seeded fits should then agree within
+    ``SINGLE_THREAD_REPRO_ABS_TOLERANCE`` absolute tolerance. Callers should
+    still treat the fit as reproducible within tolerance rather than exactly
+    identical across machines or BLAS threading setups.
 
     References: Krishnan et al. (2017) §3-4
     """

--- a/src/hft_hmm/models/dmm.py
+++ b/src/hft_hmm/models/dmm.py
@@ -861,21 +861,19 @@ def expected_next_returns_from_dmm(
 
     try:
         with torch.no_grad():
+            filtered_latent_means = _filtered_latent_mean_trajectory_tensor(
+                dmm,
+                observations=observations,
+                side_info=side_info_tensor,
+            )
             for t in range(n_obs):
-                prefix_length = t + 1
-                prefix_observations = observations[:, :prefix_length, :]
-                prefix_side_info = (
-                    side_info_tensor[:, :prefix_length, :] if side_info_tensor is not None else None
-                )
-                filtered_latent_mean = _filtered_latent_mean_for_prefix(
-                    dmm,
-                    prefix_observations=prefix_observations,
-                    prefix_side_info=prefix_side_info,
-                )
                 transition_side_info = (
                     side_info_tensor[:, t, :] if side_info_tensor is not None else None
                 )
-                next_latent_loc, _ = dmm.trans(filtered_latent_mean, transition_side_info)
+                next_latent_loc, _ = dmm.trans(
+                    filtered_latent_means[t, :].unsqueeze(0),
+                    transition_side_info,
+                )
                 emission_loc, _ = dmm.emitter(next_latent_loc)
                 expected[t] = float(emission_loc.squeeze().item())
     finally:
@@ -884,6 +882,68 @@ def expected_next_returns_from_dmm(
     if not np.all(np.isfinite(expected)):
         raise ValueError("DMM expected_next_returns must contain only finite values.")
     return pd.Series(expected, index=return_index, name="expected_next_returns")
+
+
+def filtered_latent_mean_trajectory_from_dmm(
+    fitted: DMM | DMMFitResult,
+    returns: pd.Series | np.ndarray,
+    side_info: pd.Series | pd.DataFrame | np.ndarray | None = None,
+) -> pd.DataFrame:
+    """Return the causal filtered latent-mean trajectory for a forecast window.
+
+    The DMM guide is a reverse-time smoother, so recovering a filtered
+    ``E[z_t | Δy_{1:t}]`` trajectory without look-ahead requires evaluating the
+    guide on each expanding prefix ``Δy_{1:t}`` separately. This helper reuses
+    the same prefix filter as :func:`expected_next_returns_from_dmm` and returns
+    a finite, index-aligned dataframe with one row per observed bar and one
+    column per latent dimension.
+
+    References: Krishnan et al. (2017) §3-4
+    """
+
+    dmm = _coerce_dmm_forecast_model(fitted)
+    if dmm.obs_dim != 1:
+        raise ValueError(
+            "filtered_latent_mean_trajectory_from_dmm currently supports only obs_dim=1 "
+            f"models, got obs_dim={dmm.obs_dim}."
+        )
+    return_values, return_index = _coerce_return_forecast_series(returns)
+    n_obs = return_values.shape[0]
+    parameter = next(dmm.parameters())
+    device = parameter.device
+    dtype = parameter.dtype
+
+    observations = torch.as_tensor(
+        return_values.reshape(1, n_obs, dmm.obs_dim),
+        device=device,
+        dtype=dtype,
+    )
+    side_info_tensor = _coerce_forecast_side_info(
+        side_info,
+        return_index=return_index,
+        n_obs=n_obs,
+        side_info_dim=dmm.side_info_dim,
+        device=device,
+        dtype=dtype,
+    )
+
+    was_training = dmm.training
+    dmm.eval()
+    try:
+        with torch.no_grad():
+            filtered_latent_means = _filtered_latent_mean_trajectory_tensor(
+                dmm,
+                observations=observations,
+                side_info=side_info_tensor,
+            )
+    finally:
+        dmm.train(was_training)
+
+    latent_values = filtered_latent_means.detach().cpu().numpy()
+    if not np.all(np.isfinite(latent_values)):
+        raise ValueError("DMM filtered latent trajectory must contain only finite values.")
+    columns = [f"latent_{latent_dim + 1}" for latent_dim in range(dmm.z_dim)]
+    return pd.DataFrame(latent_values, index=return_index, columns=columns)
 
 
 def _coerce_observations(observations: torch.Tensor, *, obs_dim: int) -> torch.Tensor:
@@ -1118,6 +1178,31 @@ def _filtered_latent_mean_for_prefix(
         z_loc, _ = dmm.combiner(z_prev, rnn_output_padded[:, step, :])
         z_prev = z_loc
     return z_prev
+
+
+def _filtered_latent_mean_trajectory_tensor(
+    dmm: DMM,
+    *,
+    observations: torch.Tensor,
+    side_info: torch.Tensor | None,
+) -> torch.Tensor:
+    _, time_steps, _ = observations.shape
+    latent_trajectory = torch.empty(
+        time_steps,
+        dmm.z_dim,
+        device=observations.device,
+        dtype=observations.dtype,
+    )
+    for step in range(time_steps):
+        prefix_length = step + 1
+        prefix_observations = observations[:, :prefix_length, :]
+        prefix_side_info = side_info[:, :prefix_length, :] if side_info is not None else None
+        latent_trajectory[step, :] = _filtered_latent_mean_for_prefix(
+            dmm,
+            prefix_observations=prefix_observations,
+            prefix_side_info=prefix_side_info,
+        ).squeeze(0)
+    return latent_trajectory
 
 
 def _validate_positive_int(value: int, name: str) -> None:

--- a/src/hft_hmm/selection/__init__.py
+++ b/src/hft_hmm/selection/__init__.py
@@ -8,7 +8,10 @@ from hft_hmm.selection.model_selection import (
     compare_state_counts,
     count_gaussian_hmm_parameters,
 )
-from hft_hmm.selection.plots import plot_selection_curves
+from hft_hmm.selection.plots import (
+    plot_dmm_filtered_latent_trajectory,
+    plot_selection_curves,
+)
 
 __all__ = [
     "ModelSelectionResult",
@@ -17,5 +20,6 @@ __all__ = [
     "bic",
     "compare_state_counts",
     "count_gaussian_hmm_parameters",
+    "plot_dmm_filtered_latent_trajectory",
     "plot_selection_curves",
 ]

--- a/src/hft_hmm/selection/plots.py
+++ b/src/hft_hmm/selection/plots.py
@@ -6,13 +6,20 @@ a GUI backend into memory for users that only need the numeric scoring helpers.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import Any, Final
+
+import numpy as np
+import pandas as pd
 
 from hft_hmm.core import EVALUATION_LAYER, PaperReference, reference
 from hft_hmm.selection.model_selection import ModelSelectionResult
 
 __category__: Final[str] = EVALUATION_LAYER
 SELECTION_PLOT_REFERENCE: Final[PaperReference] = reference("§4", "model-selection curves")
+DMM_TRAJECTORY_PLOT_REFERENCE: Final[PaperReference] = reference(
+    "§3-4", "DMM filtered latent-state trajectories"
+)
 
 
 def plot_selection_curves(
@@ -58,3 +65,138 @@ def plot_selection_curves(
     ax.legend()
 
     return ax
+
+
+def plot_dmm_filtered_latent_trajectory(
+    latent_trajectory: pd.DataFrame | np.ndarray,
+    *,
+    returns: pd.Series | np.ndarray | None = None,
+    expected_next_returns: pd.Series | np.ndarray | None = None,
+    max_dims: int | None = None,
+    ax: Any = None,
+) -> Any:
+    """Plot the causal DMM filtered latent-state trajectory over time.
+
+    ``latent_trajectory`` is expected to be the output of
+    ``filtered_latent_mean_trajectory_from_dmm()`` or an equivalent
+    ``(n_obs, z_dim)`` array. When ``max_dims`` is provided, the helper plots
+    the latent dimensions with the largest sample standard deviations. Optional
+    return overlays are drawn on a secondary y-axis so their scale does not
+    obscure the latent means.
+
+    References: Krishnan et al. (2017) §3-4
+    """
+    import matplotlib.pyplot as plt
+
+    latent_frame = _coerce_latent_trajectory_frame(latent_trajectory)
+    columns_to_plot = _select_latent_columns(latent_frame, max_dims=max_dims)
+
+    if ax is None:
+        _, ax = plt.subplots()
+
+    for column in columns_to_plot:
+        ax.plot(latent_frame.index, latent_frame[column], label=str(column))
+
+    ax.set_xlabel("time")
+    ax.set_ylabel("filtered latent mean")
+    ax.set_title("DMM filtered latent-state trajectory")
+
+    overlay_ax = None
+    if returns is not None or expected_next_returns is not None:
+        overlay_ax = ax.twinx()
+        overlay_ax.set_ylabel("return")
+        if returns is not None:
+            returns_series = _coerce_overlay_series(
+                returns,
+                index=latent_frame.index,
+                default_name="returns",
+            )
+            overlay_ax.plot(
+                returns_series.index,
+                returns_series.to_numpy(),
+                alpha=0.35,
+                linestyle="--",
+                label=returns_series.name,
+            )
+        if expected_next_returns is not None:
+            expected_series = _coerce_overlay_series(
+                expected_next_returns,
+                index=latent_frame.index,
+                default_name="expected_next_returns",
+            )
+            overlay_ax.plot(
+                expected_series.index,
+                expected_series.to_numpy(),
+                alpha=0.85,
+                linewidth=1.2,
+                label=expected_series.name,
+            )
+
+    handles, labels = ax.get_legend_handles_labels()
+    if overlay_ax is not None:
+        overlay_handles, overlay_labels = overlay_ax.get_legend_handles_labels()
+        handles.extend(overlay_handles)
+        labels.extend(overlay_labels)
+    if handles:
+        ax.legend(handles, labels, loc="best")
+
+    return ax
+
+
+def _coerce_latent_trajectory_frame(latent_trajectory: pd.DataFrame | np.ndarray) -> pd.DataFrame:
+    if isinstance(latent_trajectory, pd.DataFrame):
+        frame = latent_trajectory.astype(float).copy()
+    else:
+        latent_values = np.asarray(latent_trajectory, dtype=float)
+        if latent_values.ndim != 2:
+            raise ValueError(
+                "latent_trajectory must have shape (n_obs, z_dim), "
+                f"got shape {latent_values.shape}."
+            )
+        frame = pd.DataFrame(
+            latent_values,
+            columns=[f"latent_{latent_dim + 1}" for latent_dim in range(latent_values.shape[1])],
+        )
+    if frame.empty:
+        raise ValueError("latent_trajectory must contain at least one row.")
+    if not np.isfinite(frame.to_numpy()).all():
+        raise ValueError("latent_trajectory must contain only finite values.")
+    return frame
+
+
+def _select_latent_columns(latent_frame: pd.DataFrame, *, max_dims: int | None) -> Sequence[Any]:
+    if max_dims is None:
+        return list(latent_frame.columns)
+    if max_dims < 1:
+        raise ValueError(f"max_dims must be positive when provided, got {max_dims}.")
+    if max_dims >= latent_frame.shape[1]:
+        return list(latent_frame.columns)
+    column_order = latent_frame.std(axis=0).sort_values(ascending=False).index
+    return list(column_order[:max_dims])
+
+
+def _coerce_overlay_series(
+    values: pd.Series | np.ndarray,
+    *,
+    index: pd.Index,
+    default_name: str,
+) -> pd.Series:
+    if isinstance(values, pd.Series):
+        if not values.index.equals(index):
+            raise ValueError("overlay series index must exactly match the latent trajectory index.")
+        series = values.astype(float).copy()
+    else:
+        array = np.asarray(values, dtype=float)
+        if array.ndim != 1:
+            raise ValueError(f"overlay series must be one-dimensional, got shape {array.shape}.")
+        if array.shape[0] != len(index):
+            raise ValueError(
+                "overlay series length must match the latent trajectory length, "
+                f"got {array.shape[0]} and {len(index)}."
+            )
+        series = pd.Series(array, index=index, name=default_name)
+    if not np.isfinite(series.to_numpy()).all():
+        raise ValueError("overlay series must contain only finite values.")
+    if series.name is None:
+        series = series.rename(default_name)
+    return series

--- a/tests/test_dmm.py
+++ b/tests/test_dmm.py
@@ -18,6 +18,8 @@ import torch  # noqa: E402
 from hft_hmm.core import ENGINEERING_APPROXIMATION, module_category  # noqa: E402
 from hft_hmm.models.dmm import (  # noqa: E402
     DMM,
+    SINGLE_THREAD_REPRO_ABS_TOLERANCE,
+    SINGLE_THREAD_REPRO_TORCH_THREADS,
     Combiner,
     DMMConfig,
     DMMFitResult,
@@ -422,16 +424,20 @@ def test_fit_dmm_is_reproducible_within_tolerance_at_one_thread() -> None:
         annealing_epochs=3,
         seed=23,
     )
-    atol = 1e-6
     previous_threads = torch.get_num_threads()
     try:
-        torch.set_num_threads(1)
+        torch.set_num_threads(SINGLE_THREAD_REPRO_TORCH_THREADS)
         first = fit_dmm(config, observations, side_info, seq_lengths)
         second = fit_dmm(config, observations, side_info, seq_lengths)
     finally:
         torch.set_num_threads(previous_threads)
 
-    np.testing.assert_allclose(first.loss_history, second.loss_history, atol=atol, rtol=0.0)
+    np.testing.assert_allclose(
+        first.loss_history,
+        second.loss_history,
+        atol=SINGLE_THREAD_REPRO_ABS_TOLERANCE,
+        rtol=0.0,
+    )
 
 
 def test_expected_next_returns_from_dmm_returns_index_aligned_series(

--- a/tests/test_plots_dmm.py
+++ b/tests/test_plots_dmm.py
@@ -1,0 +1,124 @@
+"""Tests for the DMM latent-trajectory plotting helper."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("pyro")
+pytest.importorskip("matplotlib")
+
+import matplotlib  # noqa: E402
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+import torch  # noqa: E402
+
+from hft_hmm.models.dmm import (  # noqa: E402
+    DMMConfig,
+    expected_next_returns_from_dmm,
+    filtered_latent_mean_trajectory_from_dmm,
+    fit_dmm,
+)
+from hft_hmm.selection.plots import plot_dmm_filtered_latent_trajectory  # noqa: E402
+
+
+def _synthetic_training_batch() -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    batch_size = 6
+    time_steps = 6
+    time_grid = torch.linspace(-1.0, 1.0, steps=time_steps, dtype=torch.float32)
+    side_template = torch.stack((time_grid, time_grid.square()), dim=1)
+    side_info = side_template.unsqueeze(0).repeat(batch_size, 1, 1)
+
+    offsets = torch.linspace(-0.15, 0.15, steps=batch_size, dtype=torch.float32).view(
+        batch_size,
+        1,
+        1,
+    )
+    observations = 0.3 * side_info[..., :1] - 0.12 * side_info[..., 1:] + offsets
+    seq_lengths = torch.full((batch_size,), time_steps, dtype=torch.long)
+    return observations, side_info, seq_lengths
+
+
+def _forecast_window_inputs(length: int = 7) -> tuple[pd.Series, pd.DataFrame]:
+    index = pd.date_range("2024-01-04 09:30:00", periods=length, freq="min")
+    returns = pd.Series(np.linspace(-0.012, 0.016, num=length), index=index, name="returns")
+    side_info = pd.DataFrame(
+        {
+            "level": np.linspace(-0.75, 0.9, num=length),
+            "curvature": np.linspace(0.2, 1.1, num=length),
+        },
+        index=index,
+    )
+    return returns, side_info
+
+
+def test_filtered_latent_trajectory_and_plot_smoke(tmp_path) -> None:
+    observations, side_info, seq_lengths = _synthetic_training_batch()
+    config = DMMConfig(
+        obs_dim=1,
+        z_dim=3,
+        emission_dim=6,
+        transition_dim=6,
+        rnn_dim=7,
+        side_info_dim=2,
+        num_epochs=4,
+        mini_batch_size=3,
+        learning_rate=1e-2,
+        beta1=0.9,
+        beta2=0.999,
+        clip_norm=5.0,
+        lr_decay=1.0,
+        weight_decay=0.0,
+        rnn_dropout_rate=0.0,
+        min_annealing_factor=0.2,
+        annealing_epochs=2,
+        seed=37,
+    )
+
+    previous_threads = torch.get_num_threads()
+    try:
+        torch.set_num_threads(1)
+        fitted = fit_dmm(config, observations, side_info, seq_lengths)
+    finally:
+        torch.set_num_threads(previous_threads)
+
+    forecast_returns, forecast_side_info = _forecast_window_inputs()
+    latent_trajectory = filtered_latent_mean_trajectory_from_dmm(
+        fitted,
+        forecast_returns,
+        forecast_side_info,
+    )
+    expected = expected_next_returns_from_dmm(
+        fitted,
+        forecast_returns,
+        forecast_side_info,
+    )
+
+    assert latent_trajectory.shape == (len(forecast_returns), config.z_dim)
+    pd.testing.assert_index_equal(latent_trajectory.index, forecast_returns.index)
+    assert np.isfinite(latent_trajectory.to_numpy()).all()
+
+    fig, ax = plt.subplots()
+    output_path = tmp_path / "dmm_latent_trajectory.png"
+    try:
+        returned_ax = plot_dmm_filtered_latent_trajectory(
+            latent_trajectory,
+            returns=forecast_returns,
+            expected_next_returns=expected,
+            ax=ax,
+        )
+        returned_ax.figure.savefig(output_path, dpi=100)
+        assert returned_ax is ax
+        assert len(ax.get_lines()) == config.z_dim
+        assert len(returned_ax.figure.axes) == 2
+        overlay_labels = {line.get_label() for line in returned_ax.figure.axes[1].get_lines()}
+        assert {"returns", "expected_next_returns"} <= overlay_labels
+    finally:
+        plt.close(fig)
+
+    assert output_path.exists()
+    assert output_path.stat().st_size > 0

--- a/tests/test_repro.py
+++ b/tests/test_repro.py
@@ -306,6 +306,121 @@ def test_repro_cli_bit_for_bit(tmp_path: Path) -> None:
     assert (printed / "log.jsonl").read_bytes() == (in_process.directory / "log.jsonl").read_bytes()
 
 
+def test_repro_cli_dmm_comparison_is_reproducible_within_tolerance_at_one_thread(
+    tmp_path: Path,
+) -> None:
+    pytest.importorskip("torch")
+    pytest.importorskip("pyro")
+
+    from hft_hmm.experiments.side_info_comparison import DMM_VARIANT
+    from hft_hmm.features.seasonality import SeasonalityConfig
+    from hft_hmm.features.splines import SplinePredictorConfig
+    from hft_hmm.features.volatility_ratio import VolatilityRatioConfig
+    from hft_hmm.models.dmm import (
+        SINGLE_THREAD_REPRO_ABS_TOLERANCE,
+        SINGLE_THREAD_REPRO_TORCH_THREADS,
+        DMMConfig,
+    )
+    from hft_hmm.models.iohmm_approx import BucketedTransitionConfig
+    from hft_hmm.models.iohmm_continuous import ContinuousIOHMMConfig
+
+    config = SideInfoComparisonConfig(
+        data=DataSourceConfig(kind="csv", path=str(SAMPLE_FIXTURE)),
+        frequency="5min",
+        walk_forward=WalkForwardConfig(
+            h_days=3,
+            t_days=1,
+            retrain_every_days=1,
+            k_values=(2,),
+            random_state=0,
+            n_iter=100,
+            tol=1e-4,
+            min_variance=1e-8,
+            variance_floor_policy="clamp",
+        ),
+        spline=SplinePredictorConfig(n_knots=5, min_obs=20),
+        bucketed_transition=BucketedTransitionConfig(n_buckets=3, smoothing=1.0),
+        continuous_iohmm=ContinuousIOHMMConfig(
+            num_warmup=5,
+            num_samples=8,
+            seed=0,
+            rhat_threshold=10.0,
+            ess_bulk_threshold=1,
+        ),
+        dmm=DMMConfig(
+            obs_dim=1,
+            z_dim=2,
+            emission_dim=4,
+            transition_dim=4,
+            rnn_dim=4,
+            num_layers=1,
+            rnn_dropout_rate=0.0,
+            num_epochs=2,
+            mini_batch_size=1,
+            learning_rate=5e-3,
+            beta1=0.9,
+            beta2=0.999,
+            clip_norm=5.0,
+            lr_decay=1.0,
+            weight_decay=0.0,
+            min_annealing_factor=0.2,
+            annealing_epochs=1,
+            seed=7,
+        ),
+        vol_ratio=VolatilityRatioConfig(fast_window=50, slow_window=100),
+        seasonality=SeasonalityConfig(bucket_minutes=1, exchange_tz="America/Chicago"),
+        train_frequency="5min",
+        eval_frequency="5min",
+        cost_bps_per_turnover=1.0,
+        notes="repro-test-dmm",
+        sha256=SAMPLE_SHA256,
+    )
+    expected_id = comparison_id(config)
+    config_yaml = tmp_path / "dmm_cfg.yaml"
+    config_yaml.write_bytes(config.to_yaml_bytes())
+
+    def _run(runs_root: Path) -> Path:
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(REPRO_SCRIPT),
+                str(config_yaml),
+                "--runs-root",
+                str(runs_root),
+                "--torch-threads",
+                str(SINGLE_THREAD_REPRO_TORCH_THREADS),
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            cwd=REPO_ROOT,
+        )
+        return Path(completed.stdout.strip())
+
+    first_dir = _run(tmp_path / "runs-a")
+    second_dir = _run(tmp_path / "runs-b")
+    assert first_dir == tmp_path / "runs-a" / expected_id
+    assert second_dir == tmp_path / "runs-b" / expected_id
+
+    first_summary = json.loads((first_dir / "summary.json").read_text())
+    second_summary = json.loads((second_dir / "summary.json").read_text())
+    first_variant = first_summary["variants"][DMM_VARIANT]["summary"]
+    second_variant = second_summary["variants"][DMM_VARIANT]["summary"]
+
+    np.testing.assert_allclose(
+        first_variant["pre-cost"]["sharpe_ratio"],
+        second_variant["pre-cost"]["sharpe_ratio"],
+        atol=SINGLE_THREAD_REPRO_ABS_TOLERANCE,
+        rtol=0.0,
+    )
+    np.testing.assert_allclose(
+        first_variant["post-cost"]["sharpe_ratio"],
+        second_variant["post-cost"]["sharpe_ratio"],
+        atol=SINGLE_THREAD_REPRO_ABS_TOLERANCE,
+        rtol=0.0,
+    )
+
+
 def test_repro_cli_rejects_missing_config(tmp_path: Path) -> None:
     missing = tmp_path / "nope.yaml"
     completed = subprocess.run(


### PR DESCRIPTION
Gate L **P5 + P6**, landed together on the shared branch.

## P5 — Reproducibility wiring (`scripts/repro.py`)
- `--torch-threads` CLI flag (lazy torch import; validates ≥1) to pin the documented contract.
- DMM reproducibility documented as a **tolerance band**, not bit-for-bit: seeded from `DMMConfig.seed` (random/numpy/torch/pyro), and at `torch.set_num_threads(1)` repeated seeded fits agree within `SINGLE_THREAD_REPRO_ABS_TOLERANCE` (1e-6). Documented in the `repro.py` / `dmm.py` / `DMMConfig` docstrings.
- Test: runs the DMM comparison twice via the CLI with `--torch-threads 1` and asserts the `dmm` variant's pre- and post-cost Sharpe agree within 1e-6.

## P6 — Latent-state trajectory figure
- `filtered_latent_mean_trajectory_from_dmm(...) -> DataFrame` — causal `E[z_t | Δy_{1:t}]` trajectory reusing the **same expanding-prefix filter** as `expected_next_returns_from_dmm` (which was refactored to share it, behavior-preserving).
- `plot_dmm_filtered_latent_trajectory(...)` in `selection/plots.py` (lazy matplotlib, optional `ax`, returns Axes, optional return/expected-return overlay on a secondary axis).
- Smoke test: fits a tiny DMM, extracts the trajectory (shape/finite/index checks), plots to an Axes, saves a PNG.

Out of scope: the headline run + write-up (P7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
